### PR TITLE
fix: call parent PluginConfig ready() method

### DIFF
--- a/netbox_cmdb/netbox_cmdb/__init__.py
+++ b/netbox_cmdb/netbox_cmdb/__init__.py
@@ -14,6 +14,7 @@ class CMDB(PluginConfig):
     default_settings = {}
 
     def ready(self):
+        super().ready()
         import netbox_cmdb.signals
 
 


### PR DESCRIPTION
<!-- Please respect the guidelines explained in CONTRIBUTING.md -->
**Description:**

Plugin's `ready()` method in `__init__.py` file wasn't calling the parent's class method, preventing the plugin to load templates, navigation menu items, etc...
