### PR TITLE
docs: add credentials notice in dev.env file

### DIFF
--- a/develop/dev.env
+++ b/develop/dev.env
@@ -1,3 +1,5 @@
+# All credentials in this file are only for local dev environment and the CI.
+# You should not use them if you are deploying our plugin in production.
 ALLOWED_HOSTS=*
 DB_NAME=netbox
 DB_USER=netbox


### PR DESCRIPTION
The goal it to notice the users to update the credentials in this file if they are willing to deploy the plugin using this config file.

The credentials in the file are only for local dev environment and the CI.