### PR TITLE
fix: import models in __init__.py

### DIFF
--- a/netbox_cmdb/netbox_cmdb/models/__init__.py
+++ b/netbox_cmdb/netbox_cmdb/models/__init__.py
@@ -1,0 +1,5 @@
+from netbox_cmdb.models.bgp import *
+from netbox_cmdb.models.bgp_community_list import *
+from netbox_cmdb.models.circuit import *
+from netbox_cmdb.models.prefix_list import *
+from netbox_cmdb.models.route_policy import *


### PR DESCRIPTION
<!-- Please respect the guidelines explained in CONTRIBUTING.md -->
**Description:**
Import models in netbox_cmdb/models/__init__.py: without this, some migrations are undetected.

Django documentation mentions `You must import the models in the __init__.py file.`.
Source: https://docs.djangoproject.com/en/4.2/topics/db/models/#organizing-models-in-a-package

<!-- Put here a simple description on what the change is supposed to do -->
...


