### PR TITLE
chore: rename dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COMPOSE_FILE=./develop/docker-compose.yml
-BUILD_NAME=netbox-plugins
+BUILD_NAME=netbox-cmdb
 PLUGINS_LIST=netbox_cmdb
 
 

--- a/develop/docker-compose.yml
+++ b/develop/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     image: postgres:13
     env_file: dev.env
     volumes:
-      - pgdata_netbox_plugins:/var/lib/postgresql/data
+      - pgdata_netbox_cmdb:/var/lib/postgresql/data
   redis:
     image: redis:5-alpine
     command:
@@ -43,4 +43,4 @@ services:
       - redis-server --appendonly yes --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
     env_file: ./dev.env
 volumes:
-  pgdata_netbox_plugins:
+  pgdata_netbox_cmdb:


### PR DESCRIPTION
To avoid collision with Criteo internal plugins.