### PR TITLE
fix(api): prefix list cannot be filtered by device name

### DIFF
--- a/netbox_cmdb/netbox_cmdb/api/prefix_list/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/prefix_list/views.py
@@ -13,4 +13,5 @@ class PrefixListViewSet(CustomNetBoxModelViewSet):
         "name",
         "ip_version",
         "device__id",
+        "device__name",
     ] + filtersets.device_location_filterset


### PR DESCRIPTION
It is a regression, it has been deleted by error in PR #14.