### PR TITLE
fix: refactor VLAN model by removing device foreign key

### DIFF
--- a/netbox_cmdb/netbox_cmdb/migrations/0037_alter_vlan_unique_together_remove_vlan_device.py
+++ b/netbox_cmdb/netbox_cmdb/migrations/0037_alter_vlan_unique_together_remove_vlan_device.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_cmdb', '0036_deviceinterface'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='vlan',
+            unique_together={('vid', 'name')},
+        ),
+        migrations.RemoveField(
+            model_name='vlan',
+            name='device',
+        ),
+    ]

--- a/netbox_cmdb/netbox_cmdb/models/vlan.py
+++ b/netbox_cmdb/netbox_cmdb/models/vlan.py
@@ -17,13 +17,6 @@ class VLAN(ChangeLoggedModel):
         validators=(MinValueValidator(VLAN_VID_MIN), MaxValueValidator(VLAN_VID_MAX)),
     )
     name = models.CharField(max_length=64)
-    device = models.ForeignKey(
-        to="dcim.Device",
-        on_delete=models.CASCADE,
-        related_name="%(class)sdevice",
-        null=False,
-        blank=False,
-    )
     description = models.CharField(max_length=100, blank=True)
     tenant = models.ForeignKey(
         to="tenancy.Tenant",
@@ -34,10 +27,10 @@ class VLAN(ChangeLoggedModel):
     )
 
     def __str__(self):
-        return f"{self.device.name}--{self.name}"
+        return f"{self.vid}--{self.name}"
 
     class Meta:
         ordering = ["vid"]
-        unique_together = ("device", "name")
+        unique_together = ("vid", "name")
         verbose_name = "VLAN"
         verbose_name_plural = "VLANs"


### PR DESCRIPTION
Fix: remove device fk in VLAN model

**Description:**
This PR refactors the VLAN model by removing the device foreign key. VLANs are attached to a device through a `DeviceLogicalInterface` (untagged_vlan/ tagged_vlans or native_vlan)

**After the commit:**

Removes the device foreign key from the VLAN model.
