### PR TITLE
fix: refactor VRF model by removing device foreign key

### DIFF
--- a/netbox_cmdb/netbox_cmdb/migrations/0038_alter_vrf_unique_together_remove_vrf_device.py
+++ b/netbox_cmdb/netbox_cmdb/migrations/0038_alter_vrf_unique_together_remove_vrf_device.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tenancy', '0007_contact_link'),
+        ('netbox_cmdb', '0037_alter_vlan_unique_together_remove_vlan_device'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='vrf',
+            unique_together={('tenant', 'name')},
+        ),
+        migrations.RemoveField(
+            model_name='vrf',
+            name='device',
+        ),
+    ]

--- a/netbox_cmdb/netbox_cmdb/models/vrf.py
+++ b/netbox_cmdb/netbox_cmdb/models/vrf.py
@@ -11,13 +11,6 @@ class VRF(ChangeLoggedModel):
     """
 
     name = models.CharField(max_length=100)
-    device = models.ForeignKey(
-        to="dcim.Device",
-        on_delete=models.CASCADE,
-        related_name="%(class)sdevice",
-        null=False,
-        blank=False,
-    )
     tenant = models.ForeignKey(
         to="tenancy.Tenant",
         on_delete=models.PROTECT,
@@ -27,10 +20,10 @@ class VRF(ChangeLoggedModel):
     )
 
     def __str__(self):
-        return f"{self.device}--{self.name}"
+        return f"{self.tenant}--{self.name}"
 
     class Meta:
         ordering = ["name"]
-        unique_together = ("device", "name")
+        unique_together = ("tenant", "name")
         verbose_name = "VRF"
         verbose_name_plural = "VRFs"


### PR DESCRIPTION
Fix: remove device fk in VRF model

**Description:**
This PR refactors the VRF model by removing the device foreign key. VRFs are attached to a device through others entities such as LogicalInterface, BGP model(s), etc

**After the commit:**

Removes the device foreign key from the VRF model.