### PR TITLE
fix(snmp): Enhance API output

### DIFF
--- a/netbox_cmdb/netbox_cmdb/api/snmp/serializers.py
+++ b/netbox_cmdb/netbox_cmdb/api/snmp/serializers.py
@@ -3,6 +3,7 @@
 from rest_framework.serializers import ModelSerializer
 
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
+from netbox_cmdb.api.common_serializers import CommonDeviceSerializer
 
 
 class SNMPCommunitySerializer(ModelSerializer):
@@ -12,7 +13,26 @@ class SNMPCommunitySerializer(ModelSerializer):
         fields = "__all__"
 
 
+class SNMPCommunityReadSerializer(ModelSerializer):
+
+    class Meta:
+        model = SNMPCommunity
+        fields = ["community", "type"]
+
+
+class SNMPReadSerializer(ModelSerializer):
+
+    device = CommonDeviceSerializer()
+    community_list = SNMPCommunityReadSerializer(many=True)
+
+    class Meta:
+        model = SNMP
+        fields = "__all__"
+
+
 class SNMPSerializer(ModelSerializer):
+
+    device = CommonDeviceSerializer()
 
     class Meta:
         model = SNMP

--- a/netbox_cmdb/netbox_cmdb/api/snmp/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/snmp/views.py
@@ -4,7 +4,12 @@ from netbox_cmdb import filtersets
 
 from netbox_cmdb.api.viewsets import CustomNetBoxModelViewSet
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
-from netbox_cmdb.api.snmp.serializers import SNMPCommunitySerializer, SNMPSerializer
+from netbox_cmdb.api.snmp.serializers import (
+    SNMPCommunitySerializer,
+    SNMPReadSerializer,
+    SNMPSerializer,
+)
+from rest_framework.response import Response
 
 
 class SNMPCommunityViewSet(CustomNetBoxModelViewSet):
@@ -26,3 +31,8 @@ class SNMPViewSet(CustomNetBoxModelViewSet):
         "device__id",
         "device__name",
     ] + filtersets.device_location_filterset
+
+    def list(self, request):
+        queryset = SNMP.objects.all()
+        serializer = SNMPReadSerializer(queryset, many=True)
+        return Response(serializer.data)

--- a/netbox_cmdb/netbox_cmdb/tests/snmp/test_snmp_serializer.py
+++ b/netbox_cmdb/netbox_cmdb/tests/snmp/test_snmp_serializer.py
@@ -15,6 +15,7 @@ class SNMPCommunitySerializerCreate(BaseTestCase):
 
         assert community1.community == "my_community"
         assert community1.type == SNMPCommunityType.RO
+        community1.save()
 
         data = {
             "device": self.device1.pk,


### PR DESCRIPTION
Fixes

Enhanced the /api/plugins/cmdb/snmp/ endpoint to include detailed information for devices and communities, not just the primary key (pk).

New output:
```
{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 1,
            "device": {
                "id": 1,
                "name": "device1"
            },
            "community_list": [
                {
                    "community": "dfqsfqsfqsfqsfd",
                    "type": "readonly"
                }
            ],
            "created": "2024-06-10T07:37:29.238195Z",
            "last_updated": "2024-06-11T13:08:11.378498Z",
            "location": "location1",
            "contact": "contact"
        }
    ]
}
```