### PR TITLE
fix(snmp): add paginator for API output

### DIFF
--- a/netbox_cmdb/netbox_cmdb/api/snmp/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/snmp/views.py
@@ -32,7 +32,7 @@ class SNMPViewSet(CustomNetBoxModelViewSet):
         "device__name",
     ] + filtersets.device_location_filterset
 
-    def list(self, request):
-        queryset = SNMP.objects.all()
-        serializer = SNMPReadSerializer(queryset, many=True)
-        return Response(serializer.data)
+    def get_serializer_class(self):
+        if self.action == "list":
+            return SNMPReadSerializer
+        return SNMPSerializer


### PR DESCRIPTION
Fixes: 

Enhanced the /api/plugins/cmdb/snmp/ endpoint to include pagination by using the upper class method list.
Updated get_serializer_class accordingly.

Updated output
```{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 1,
            "device": {
                "id": 1,
                "name": "device1"
            },
            "community_list": [
                {
                    "community": "dfqsfqsfqsfqsfd",
                    "type": "readonly"
                }
            ],
            "created": "2024-06-10T07:37:29.238195Z",
            "last_updated": "2024-06-11T13:08:11.378498Z",
            "location": "location1",
            "contact": "contact"
        }
    ]
}```