### PR TITLE
Limit SNMP communities

### DIFF
--- a/netbox_cmdb/netbox_cmdb/api/snmp/serializers.py
+++ b/netbox_cmdb/netbox_cmdb/api/snmp/serializers.py
@@ -1,9 +1,10 @@
 """Route Policy serializers."""
 
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import ModelSerializer, ValidationError
 
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.api.common_serializers import CommonDeviceSerializer
+from netbox_cmdb.constants import MAX_COMMUNITY_PER_DEVICE
 
 
 class SNMPCommunitySerializer(ModelSerializer):
@@ -37,3 +38,10 @@ class SNMPSerializer(ModelSerializer):
     class Meta:
         model = SNMP
         fields = "__all__"
+
+    def validate_community_list(self, value):
+        if len(value) > MAX_COMMUNITY_PER_DEVICE:
+            raise ValidationError(
+                f"You cannot select more than {MAX_COMMUNITY_PER_DEVICE} SNMP Communities."
+            )
+        return value

--- a/netbox_cmdb/netbox_cmdb/constants.py
+++ b/netbox_cmdb/netbox_cmdb/constants.py
@@ -1,2 +1,5 @@
 BGP_MIN_ASN = 1
 BGP_MAX_ASN = 4294967294
+
+# As SONIC device don't support more than 1 community
+MAX_COMMUNITY_PER_DEVICE = 1

--- a/netbox_cmdb/netbox_cmdb/forms.py
+++ b/netbox_cmdb/netbox_cmdb/forms.py
@@ -7,6 +7,7 @@ from django import forms
 from django.utils.translation import gettext as _
 from extras.models import Tag
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
+from netbox_cmdb.constants import MAX_COMMUNITY_PER_DEVICE
 from utilities.forms import DynamicModelMultipleChoiceField
 from utilities.forms.fields import DynamicModelChoiceField, MultipleChoiceField
 
@@ -92,6 +93,14 @@ class SNMPGroupForm(NetBoxModelForm):
     class Meta:
         model = SNMP
         fields = ["device", "community_list", "location", "contact"]
+
+    def clean_community_list(self):
+        community_list = self.cleaned_data.get("community_list")
+        if len(community_list) > MAX_COMMUNITY_PER_DEVICE:
+            raise forms.ValidationError(
+                f"You cannot select more than {MAX_COMMUNITY_PER_DEVICE} SNMP Communities."
+            )
+        return community_list
 
 
 class SNMPCommunityGroupForm(NetBoxModelForm):

--- a/netbox_cmdb/netbox_cmdb/tests/snmp/test_snmp_serializer.py
+++ b/netbox_cmdb/netbox_cmdb/tests/snmp/test_snmp_serializer.py
@@ -34,3 +34,20 @@ class SNMPCommunitySerializerCreate(BaseTestCase):
         assert conf.contact == "my_team"
         assert conf.community_list.all()[0] == community1
         assert conf.device == self.device1
+
+        data = {"name": "my_comm2", "community": "my_community2", "type": "readonly"}
+        snmpcommunity_serializer = SNMPCommunitySerializer(data=data)
+        assert snmpcommunity_serializer.is_valid() == True
+        snmpcommunity_serializer.save()
+        community2 = SNMPCommunity.objects.get(name="my_comm2")
+
+        data = {
+            "device": self.device2.pk,
+            "community_list": [community1.pk, community2.pk],
+            "location": "my_location",
+            "contact": "my_team",
+        }
+
+        snmp_serializer = SNMPSerializer(data=data)
+        # We are trying to add more than 1 community to the device
+        assert snmp_serializer.is_valid() == False


### PR DESCRIPTION
As Sonic devices do not accept more than one SNMP community, we prefer to limit to the lowest common denominator.

When you try to add more than 1 community, you have this message

![Screenshot 2024-07-10 at 09-45-57 Add a new snmp NetBox](https://github.com/criteo/netbox-network-cmdb/assets/15176248/1153f672-b8e3-4511-8441-d13fe834ed35)




