### PR TITLE
fix(api): safi disappearing for PATCH requests

### DIFF
--- a/netbox_cmdb/netbox_cmdb/api/bgp/serializers.py
+++ b/netbox_cmdb/netbox_cmdb/api/bgp/serializers.py
@@ -189,7 +189,7 @@ class BGPSessionSerializer(ModelSerializer):
         bgp_peers["peer_b"] = DeviceBGPSession.objects.get(peer_b=instance)
         for peer, peer_instance in bgp_peers.items():
             # pop afi safi data for later creation/update
-            afi_safis_data[peer] = peers_data[peer].pop("afi_safis", {})
+            afi_safis_data[peer] = peers_data[peer].pop("afi_safis", None)
 
             # update peer instance with provided data
             peer_instance.device = peers_data[peer].get("device", peer_instance.device)
@@ -215,6 +215,11 @@ class BGPSessionSerializer(ModelSerializer):
                 "route_policy_out", peer_instance.route_policy_out
             )
             peer_instance.save()
+
+            # handle safi
+            if afi_safis_data[peer] is None:
+                # useful for PATCH requests: if the field is empty, we don't change anything
+                continue
 
             # get current list of afi safi
             current_afi_safis = list(AfiSafi.objects.filter(device_bgp_session=peer_instance))


### PR DESCRIPTION
When trying to update a BGP session via a PATCH request, it removes the safis even if the key is not in the request:

```
[
    {
        "id": 1,
        "peer_a": {
            "device": {"id": 178623, "name": "toto"},
            "local_address": {"id": 1, "address": "10.0.0.0/31"},
            "afi_safis": [
                {
                    "id": 1,
                    "route_policy_in": None,
                    "route_policy_out": {
                        "name": "MAINTENANCE",
                        "device": {"name": "toto"},
                    },
                    "afi_safi_name": "ipv4-unicast",
                }
            ],
        },
        "peer_b": {
            "device": {"id": 2, "name": "tata"},
            "local_address": {"id": 2, "address": "10.0.0.1/31"},
        },
    }
]
```

here, the peer_a is updated with the new afi safi settings, but peer_b looses its safis if it had one.