### PR TITLE
Add endpoint removing all objects attached to a device

### DIFF
--- a/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
@@ -11,6 +11,7 @@ from netbox.api.authentication import IsAuthenticatedOrLoginNotRequired
 from netbox_cmdb.models.bgp import BGPPeerGroup, BGPSession, DeviceBGPSession
 from netbox_cmdb.models.prefix_list import PrefixList
 from netbox_cmdb.models.route_policy import RoutePolicy
+from netbox_cmdb.models.snmp import SNMP
 
 
 class DeleteAllCMDBObjectsRelatedToDeviceSerializer(serializers.Serializer):
@@ -46,6 +47,7 @@ class DeleteAllCMDBObjectsRelatedToDevice(APIView):
                 BGPPeerGroup.objects.filter(device__name=device_name).delete()
                 RoutePolicy.objects.filter(device__name=device_name).delete()
                 PrefixList.objects.filter(device__name=device_name).delete()
+                SNMP.objects.filter(device__name=device_name).delete()
             except Exception as e:
                 return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 

--- a/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
@@ -1,0 +1,55 @@
+from django.db import transaction
+from django.db.models import Q
+from drf_yasg import openapi
+from drf_yasg.openapi import Parameter
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from netbox.api.authentication import IsAuthenticatedOrLoginNotRequired
+from netbox_cmdb.models.bgp import BGPPeerGroup, BGPSession, DeviceBGPSession
+from netbox_cmdb.models.prefix_list import PrefixList
+from netbox_cmdb.models.route_policy import RoutePolicy
+
+
+class DeleteAllCMDBObjectsRelatedToDeviceSerializer(serializers.Serializer):
+    device_name = serializers.CharField()
+
+
+class DeleteAllCMDBObjectsRelatedToDevice(APIView):
+
+    permission_classes = [IsAuthenticatedOrLoginNotRequired]
+
+    @swagger_auto_schema(
+        request_body=DeleteAllCMDBObjectsRelatedToDeviceSerializer,
+        responses={
+            status.HTTP_200_OK: "Objects related to device have been deleted successfully",
+            status.HTTP_400_BAD_REQUEST: "Bad Request: Device name is required",
+            status.HTTP_500_INTERNAL_SERVER_ERROR: "Internal Server Error: Something went wrong on the server",
+        },
+    )
+    def post(self, request):
+        device_name = request.data.get("device_name", None)
+        if device_name is None:
+            return Response(
+                {"error": "Device name is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        with transaction.atomic():
+            try:
+                # Delete objects in reverse order of dependencies
+                BGPSession.objects.filter(
+                    Q(peer_a__device__name=device_name) | Q(peer_b__device__name=device_name)
+                ).delete()
+                DeviceBGPSession.objects.filter(device__name=device_name).delete()
+                BGPPeerGroup.objects.filter(device__name=device_name).delete()
+                RoutePolicy.objects.filter(device__name=device_name).delete()
+                PrefixList.objects.filter(device__name=device_name).delete()
+            except Exception as e:
+                return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        return Response(
+            {"message": f"Objects related to device {device_name} have been deleted successfully"},
+            status=status.HTTP_200_OK,
+        )

--- a/netbox_cmdb/netbox_cmdb/api/urls.py
+++ b/netbox_cmdb/netbox_cmdb/api/urls.py
@@ -12,6 +12,7 @@ from netbox_cmdb.api.bgp_community_list.views import BGPCommunityListViewSet
 from netbox_cmdb.api.prefix_list.views import PrefixListViewSet
 from netbox_cmdb.api.route_policy.views import RoutePolicyViewSet
 from netbox_cmdb.api.snmp.views import SNMPCommunityViewSet, SNMPViewSet
+from netbox_cmdb.api.cmdb.views import DeleteAllCMDBObjectsRelatedToDevice
 
 router = NetBoxRouter()
 
@@ -29,6 +30,11 @@ urlpatterns = [
     path(
         "asns/available-asn/",
         AvailableASNsView.as_view(),
+        name="asns-available-asn",
+    ),
+    path(
+        "cmdb/delete-all-objects/",
+        DeleteAllCMDBObjectsRelatedToDevice.as_view(),
         name="asns-available-asn",
     ),
 ]


### PR DESCRIPTION
**Description:**

* this change introduces a new API endpoints `/api/plugins/cmdb/cmdb/delete-all-objects/` taking as input a device name
* all objects referencing this device into CMDB objects (BGP sessions, Device BGP sessions, route policies, SNMP, etc...) will be removed from the database