### PR TITLE
Device decommissioning  webui

### DIFF
--- a/netbox_cmdb/netbox_cmdb/api/bgp/serializers.py
+++ b/netbox_cmdb/netbox_cmdb/api/bgp/serializers.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from ipam.api.nested_serializers import NestedIPAddressSerializer
+from netbox.api.serializers import WritableNestedSerializer
 from rest_framework import serializers
 from rest_framework.serializers import (
     IntegerField,
@@ -9,7 +10,6 @@ from rest_framework.serializers import (
 )
 from tenancy.api.nested_serializers import NestedTenantSerializer
 
-from netbox.api.serializers import WritableNestedSerializer
 from netbox_cmdb.api.common_serializers import CommonDeviceSerializer
 from netbox_cmdb.choices import AssetMonitoringStateChoices
 from netbox_cmdb.constants import BGP_MAX_ASN, BGP_MIN_ASN

--- a/netbox_cmdb/netbox_cmdb/api/bgp/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/bgp/views.py
@@ -2,12 +2,12 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import transaction
 from django_pglocks import advisory_lock
 from drf_yasg.utils import swagger_auto_schema
+from netbox.api.viewsets.mixins import ObjectValidationMixin
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from netbox.api.viewsets.mixins import ObjectValidationMixin
 from netbox_cmdb import filtersets
 from netbox_cmdb.api.bgp.serializers import (
     AvailableAsnSerializer,

--- a/netbox_cmdb/netbox_cmdb/api/bgp_community_list/serializers.py
+++ b/netbox_cmdb/netbox_cmdb/api/bgp_community_list/serializers.py
@@ -1,8 +1,9 @@
 """Route Policy serializers."""
 
+from rest_framework.serializers import ModelSerializer, ValidationError
+
 from netbox_cmdb.api.common_serializers import CommonDeviceSerializer
 from netbox_cmdb.models.bgp_community_list import BGPCommunityList, BGPCommunityListTerm
-from rest_framework.serializers import ModelSerializer, ValidationError
 
 
 class BGPCommunityListTermSerializer(ModelSerializer):

--- a/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
@@ -37,8 +37,8 @@ class DeleteAllCMDBObjectsRelatedToDevice(APIView):
                 {"error": "Device name is required"}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        with transaction.atomic():
-            try:
+        try:
+            with transaction.atomic():
                 # Delete objects in reverse order of dependencies
                 BGPSession.objects.filter(
                     Q(peer_a__device__name=device_name) | Q(peer_b__device__name=device_name)
@@ -48,8 +48,8 @@ class DeleteAllCMDBObjectsRelatedToDevice(APIView):
                 RoutePolicy.objects.filter(device__name=device_name).delete()
                 PrefixList.objects.filter(device__name=device_name).delete()
                 SNMP.objects.filter(device__name=device_name).delete()
-            except Exception as e:
-                return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         return Response(
             {"message": f"Objects related to device {device_name} have been deleted successfully"},

--- a/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
@@ -3,11 +3,11 @@ from django.db.models import Q
 from drf_yasg import openapi
 from drf_yasg.openapi import Parameter
 from drf_yasg.utils import swagger_auto_schema
+from netbox.api.authentication import IsAuthenticatedOrLoginNotRequired
 from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from netbox.api.authentication import IsAuthenticatedOrLoginNotRequired
 from netbox_cmdb.models.bgp import BGPPeerGroup, BGPSession, DeviceBGPSession
 from netbox_cmdb.models.bgp_community_list import BGPCommunityList
 from netbox_cmdb.models.prefix_list import PrefixList

--- a/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/cmdb/views.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 
 from netbox.api.authentication import IsAuthenticatedOrLoginNotRequired
 from netbox_cmdb.models.bgp import BGPPeerGroup, BGPSession, DeviceBGPSession
+from netbox_cmdb.models.bgp_community_list import BGPCommunityList
 from netbox_cmdb.models.prefix_list import PrefixList
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP
@@ -47,6 +48,7 @@ class DeleteAllCMDBObjectsRelatedToDevice(APIView):
                 BGPPeerGroup.objects.filter(device__name=device_name).delete()
                 RoutePolicy.objects.filter(device__name=device_name).delete()
                 PrefixList.objects.filter(device__name=device_name).delete()
+                BGPCommunityList.objects.filter(device_name=device_name).delete()
                 SNMP.objects.filter(device__name=device_name).delete()
         except Exception as e:
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/netbox_cmdb/netbox_cmdb/api/route_policy/serializers.py
+++ b/netbox_cmdb/netbox_cmdb/api/route_policy/serializers.py
@@ -1,10 +1,10 @@
 """Route Policy serializers."""
 
 from django.core.exceptions import ValidationError
+from netbox.api.serializers import WritableNestedSerializer
 from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
-from netbox.api.serializers import WritableNestedSerializer
 from netbox_cmdb.api.bgp.serializers import AsnSerializer
 from netbox_cmdb.api.common_serializers import CommonDeviceSerializer
 from netbox_cmdb.models.bgp_community_list import BGPCommunityList

--- a/netbox_cmdb/netbox_cmdb/api/snmp/serializers.py
+++ b/netbox_cmdb/netbox_cmdb/api/snmp/serializers.py
@@ -2,9 +2,9 @@
 
 from rest_framework.serializers import ModelSerializer, ValidationError
 
-from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.api.common_serializers import CommonDeviceSerializer
 from netbox_cmdb.constants import MAX_COMMUNITY_PER_DEVICE
+from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 
 
 class SNMPCommunitySerializer(ModelSerializer):

--- a/netbox_cmdb/netbox_cmdb/api/snmp/views.py
+++ b/netbox_cmdb/netbox_cmdb/api/snmp/views.py
@@ -1,15 +1,15 @@
 """Route Policy views."""
 
-from netbox_cmdb import filtersets
+from rest_framework.response import Response
 
-from netbox_cmdb.api.viewsets import CustomNetBoxModelViewSet
-from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
+from netbox_cmdb import filtersets
 from netbox_cmdb.api.snmp.serializers import (
     SNMPCommunitySerializer,
     SNMPReadSerializer,
     SNMPSerializer,
 )
-from rest_framework.response import Response
+from netbox_cmdb.api.viewsets import CustomNetBoxModelViewSet
+from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 
 
 class SNMPCommunityViewSet(CustomNetBoxModelViewSet):

--- a/netbox_cmdb/netbox_cmdb/filtersets.py
+++ b/netbox_cmdb/netbox_cmdb/filtersets.py
@@ -1,12 +1,12 @@
 import django_filters
 from django.db.models import Q
-from netbox_cmdb.models.snmp import SNMP
+from netbox.filtersets import ChangeLoggedModelFilterSet
 from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import MultiValueCharFilter
 
-from netbox.filtersets import ChangeLoggedModelFilterSet
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession
 from netbox_cmdb.models.route_policy import RoutePolicy
+from netbox_cmdb.models.snmp import SNMP
 
 device_location_filterset = [
     "device__location__name",

--- a/netbox_cmdb/netbox_cmdb/forms.py
+++ b/netbox_cmdb/netbox_cmdb/forms.py
@@ -8,10 +8,10 @@ from dcim.models.sites import SiteGroup
 from django import forms
 from django.utils.translation import gettext as _
 from extras.models import Tag
+from netbox.forms import NetBoxModelFilterSetForm, NetBoxModelForm
 from utilities.forms import DynamicModelMultipleChoiceField
 from utilities.forms.fields import DynamicModelChoiceField, MultipleChoiceField
 
-from netbox.forms import NetBoxModelFilterSetForm, NetBoxModelForm
 from netbox_cmdb.choices import AssetMonitoringStateChoices, AssetStateChoices
 from netbox_cmdb.constants import MAX_COMMUNITY_PER_DEVICE
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession

--- a/netbox_cmdb/netbox_cmdb/models/bgp.py
+++ b/netbox_cmdb/netbox_cmdb/models/bgp.py
@@ -4,10 +4,10 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import Q
 from django.urls import reverse
+from netbox.models import ChangeLoggedModel
 from utilities.choices import ChoiceSet
 from utilities.querysets import RestrictedQuerySet
 
-from netbox.models import ChangeLoggedModel
 from netbox_cmdb.choices import AssetMonitoringStateChoices, AssetStateChoices
 from netbox_cmdb.constants import BGP_MAX_ASN, BGP_MIN_ASN
 

--- a/netbox_cmdb/netbox_cmdb/models/interface.py
+++ b/netbox_cmdb/netbox_cmdb/models/interface.py
@@ -1,7 +1,8 @@
-from django.db import models
-from netbox_cmdb.choices import AssetStateChoices, AssetMonitoringStateChoices
-from netbox.models import ChangeLoggedModel
 from django.core.exceptions import ValidationError
+from django.db import models
+from netbox.models import ChangeLoggedModel
+
+from netbox_cmdb.choices import AssetMonitoringStateChoices, AssetStateChoices
 
 FEC_CHOICES = [
     (None, "None"),

--- a/netbox_cmdb/netbox_cmdb/models/route_policy.py
+++ b/netbox_cmdb/netbox_cmdb/models/route_policy.py
@@ -27,7 +27,7 @@ class RoutePolicy(ChangeLoggedModel):
     objects = RestrictedQuerySet.as_manager()
 
     def __str__(self):
-        return str(self.name)
+        return f"{self.device}-{self.name}"
 
     def __repr__(self):
         return str(self.name)

--- a/netbox_cmdb/netbox_cmdb/models/route_policy.py
+++ b/netbox_cmdb/netbox_cmdb/models/route_policy.py
@@ -1,9 +1,9 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
+from netbox.models import ChangeLoggedModel
 from utilities.querysets import RestrictedQuerySet
 
-from netbox.models import ChangeLoggedModel
 from netbox_cmdb.choices import DecisionChoice
 from netbox_cmdb.fields import CustomIPAddressField
 

--- a/netbox_cmdb/netbox_cmdb/models/snmp.py
+++ b/netbox_cmdb/netbox_cmdb/models/snmp.py
@@ -1,8 +1,9 @@
-from django.db import models
-from netbox_cmdb.choices import SNMPCommunityType
-from netbox.models import ChangeLoggedModel
-from django.core.exceptions import ValidationError
 from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import ValidationError
+from django.db import models
+from netbox.models import ChangeLoggedModel
+
+from netbox_cmdb.choices import SNMPCommunityType
 
 
 class SNMPCommunity(ChangeLoggedModel):

--- a/netbox_cmdb/netbox_cmdb/models/snmp.py
+++ b/netbox_cmdb/netbox_cmdb/models/snmp.py
@@ -44,4 +44,4 @@ class SNMP(ChangeLoggedModel):
         verbose_name_plural = "SNMP"
 
     def __str__(self):
-        return f"SNMP configuration of {self.device.name}"
+        return f"{self.device.name}-SNMP"

--- a/netbox_cmdb/netbox_cmdb/signals.py
+++ b/netbox_cmdb/netbox_cmdb/signals.py
@@ -1,5 +1,6 @@
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
+
 from netbox_cmdb.models.bgp import BGPSession
 
 

--- a/netbox_cmdb/netbox_cmdb/tables.py
+++ b/netbox_cmdb/netbox_cmdb/tables.py
@@ -1,8 +1,8 @@
 """Tables."""
 
 import django_tables2 as tables
-
 from netbox.tables import NetBoxTable, columns
+
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity

--- a/netbox_cmdb/netbox_cmdb/template_content.py
+++ b/netbox_cmdb/netbox_cmdb/template_content.py
@@ -1,0 +1,14 @@
+from extras.plugins import PluginTemplateExtension
+
+class Decommisioning(PluginTemplateExtension):
+    model = 'dcim.device'
+
+    def buttons(self):
+        return (
+            f'<a href="#" hx-get="/plugins/cmdb/decommisioning/{self.context["object"].id}/delete" '
+            'hx-target="#htmx-modal-content" class="btn btn-sm btn-danger" data-bs-toggle="modal" data-bs-target="#htmx-modal" '
+            'class="btn btn-sm btn-danger">Decommission</a>'
+        )
+
+
+template_extensions = [Decommisioning]

--- a/netbox_cmdb/netbox_cmdb/template_content.py
+++ b/netbox_cmdb/netbox_cmdb/template_content.py
@@ -1,7 +1,8 @@
 from extras.plugins import PluginTemplateExtension
 
+
 class Decommisioning(PluginTemplateExtension):
-    model = 'dcim.device'
+    model = "dcim.device"
 
     def buttons(self):
         return (

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/decommissioning.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/decommissioning.html
@@ -1,0 +1,43 @@
+{% extends "base/layout.html" %}
+
+{% block content-wrapper %}
+<div class="container mt-3 border rounded">
+  {% if error %}
+  <div class="alert alert-danger">{{ error }}</div>
+  {% else %}
+  <div class="mt-3 mb-2">
+    <h5 class="mb-2">Deleted objects</h5>
+
+    <div class="card-header border-0">
+        <h6 class="card-title">Device</h6>
+        <div class="card-body table-responsive">
+            <table class="table table-hover object-list">
+            <tr>
+                <td>{{ deleted_device }}</td>
+            </tr>
+            </table>
+        </div>
+    </div>
+
+    {% for key, objects in deleted_objects.items %}
+        {% if objects %}
+    <div class="card-header border-0">
+        <h6 class="card-title">{{ key }}</h6>
+        <div class="card-body table-responsive">
+            <table class="table table-hover object-list">
+            {% for obj in objects %}
+            <tr>
+                <td>{{ obj }}</td>
+            </tr>
+            {% endfor %}
+            </table>
+        </div>
+    </div>
+        {% endif %}
+    {% endfor %}
+
+
+  </div>
+  {% endif %}
+</div>
+{% endblock content-wrapper%}

--- a/netbox_cmdb/netbox_cmdb/tests/bgp_community_list/test_bgp_community_list_serializer.py
+++ b/netbox_cmdb/netbox_cmdb/tests/bgp_community_list/test_bgp_community_list_serializer.py
@@ -1,9 +1,10 @@
 from dcim.models.devices import Device, DeviceRole, DeviceType, Manufacturer
 from dcim.models.sites import Site
 from django.test import TestCase
+from rest_framework.serializers import ValidationError
+
 from netbox_cmdb.api.bgp_community_list.serializers import BGPCommunityListSerializer
 from netbox_cmdb.models.bgp_community_list import BGPCommunityList, BGPCommunityListTerm
-from rest_framework.serializers import ValidationError
 
 
 def validate(device, data):

--- a/netbox_cmdb/netbox_cmdb/tests/common.py
+++ b/netbox_cmdb/netbox_cmdb/tests/common.py
@@ -3,6 +3,7 @@ from dcim.models.sites import Site
 from django.test import TestCase
 from ipam.models.ip import IPAddress
 from tenancy.models.tenants import Tenant
+
 from netbox_cmdb.models.bgp import ASN
 
 

--- a/netbox_cmdb/netbox_cmdb/tests/prefix_list/test_prefix_list_models.py
+++ b/netbox_cmdb/netbox_cmdb/tests/prefix_list/test_prefix_list_models.py
@@ -2,6 +2,7 @@ from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 from django.forms import ValidationError
 from django.test import TestCase
 from netaddr import IPNetwork
+
 from netbox_cmdb.models.prefix_list import PrefixList, PrefixListTerm
 
 

--- a/netbox_cmdb/netbox_cmdb/tests/snmp/test_snmp_serializer.py
+++ b/netbox_cmdb/netbox_cmdb/tests/snmp/test_snmp_serializer.py
@@ -1,6 +1,6 @@
 from netbox_cmdb.api.snmp.serializers import SNMPCommunitySerializer, SNMPSerializer
-from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.choices import SNMPCommunityType
+from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.tests.common import BaseTestCase
 
 

--- a/netbox_cmdb/netbox_cmdb/urls.py
+++ b/netbox_cmdb/netbox_cmdb/urls.py
@@ -38,7 +38,11 @@ from netbox_cmdb.views import (
 )
 
 urlpatterns = [
-    path("decommisioning/<int:pk>/delete", DecommissioningView.as_view(), name="decommisioning_delete"),
+    path(
+        "decommisioning/<int:pk>/delete",
+        DecommissioningView.as_view(),
+        name="decommisioning_delete",
+    ),
     # ASN
     path("asn/", ASNListView.as_view(), name="asn_list"),
     path("asn/add/", ASNEditView.as_view(), name="asn_add"),

--- a/netbox_cmdb/netbox_cmdb/urls.py
+++ b/netbox_cmdb/netbox_cmdb/urls.py
@@ -4,8 +4,8 @@ from django.urls import path
 from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
 
 from netbox_cmdb.models.bgp import *
-from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.route_policy import RoutePolicy
+from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.views import (
     ASNDeleteView,
     ASNEditView,
@@ -20,12 +20,7 @@ from netbox_cmdb.views import (
     BGPSessionEditView,
     BGPSessionListView,
     BGPSessionView,
-    SNMPCommunityDeleteView,
-    SNMPCommunityEditView,
-    SNMPCommunityListView,
-    SNMPDeleteView,
-    SNMPEditView,
-    SNMPListView,
+    DecommissioningView,
     DeviceBGPSessionEditView,
     DeviceBGPSessionListView,
     DeviceBGPSessionView,
@@ -34,9 +29,16 @@ from netbox_cmdb.views import (
     RoutePolicyEditView,
     RoutePolicyListView,
     RoutePolicyView,
+    SNMPCommunityDeleteView,
+    SNMPCommunityEditView,
+    SNMPCommunityListView,
+    SNMPDeleteView,
+    SNMPEditView,
+    SNMPListView,
 )
 
 urlpatterns = [
+    path("decommisioning/<int:pk>/delete", DecommissioningView.as_view(), name="decommisioning_delete"),
     # ASN
     path("asn/", ASNListView.as_view(), name="asn_list"),
     path("asn/add/", ASNEditView.as_view(), name="asn_add"),

--- a/netbox_cmdb/netbox_cmdb/views.py
+++ b/netbox_cmdb/netbox_cmdb/views.py
@@ -1,7 +1,14 @@
 """Views."""
 
-from utilities.utils import count_related
+import logging
+import time
 
+from dcim.models import Device
+from django.db import transaction
+from django.db.models import Q
+from django.shortcuts import render
+from django.urls import reverse
+from django.views.generic import View
 from netbox.views.generic import (
     ObjectDeleteView,
     ObjectEditView,
@@ -9,6 +16,12 @@ from netbox.views.generic import (
     ObjectView,
 )
 from netbox.views.generic.bulk_views import BulkDeleteView
+from rest_framework import status
+from rest_framework.response import Response
+from utilities.forms import ConfirmationForm
+from utilities.htmx import is_htmx
+from utilities.utils import count_related, get_viewname
+
 from netbox_cmdb.filtersets import (
     ASNFilterSet,
     BGPPeerGroupFilterSet,
@@ -35,6 +48,8 @@ from netbox_cmdb.models.bgp import (
     BGPSession,
     DeviceBGPSession,
 )
+from netbox_cmdb.models.bgp_community_list import BGPCommunityList
+from netbox_cmdb.models.prefix_list import PrefixList
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.tables import (
@@ -46,6 +61,110 @@ from netbox_cmdb.tables import (
     SNMPCommunityTable,
     SNMPTable,
 )
+
+
+## Decommission a device
+class DecommissioningView(ObjectDeleteView):
+    queryset = Device.objects.all()
+    template_name = "netbox_cmdb/decommissioning.html"
+
+    def get(self, request, *args, **kwargs):
+        """
+        GET request handler.
+
+        Args:
+            request: The current request
+        """
+        obj = self.get_object(**kwargs)
+        form = ConfirmationForm(initial=request.GET)
+
+        # If this is an HTMX request, return only the rendered deletion form as modal content
+        if is_htmx(request):
+            # form_url = reverse("decommisioning_delete", kwargs={'pk': obj.pk})
+            form_url = f"/plugins/cmdb/decommisioning/{kwargs['pk']}/delete"
+            return render(
+                request,
+                "htmx/delete_form.html",
+                {
+                    "object": obj,
+                    "object_type": self.queryset.model._meta.verbose_name,
+                    "form": form,
+                    "form_url": form_url,
+                    **self.get_extra_context(request, obj),
+                },
+            )
+
+        return render(
+            request,
+            self.template_name,
+            {
+                "object": obj,
+                "form": form,
+                "return_url": self.get_return_url(request, obj),
+                **self.get_extra_context(request, obj),
+            },
+        )
+
+    def post(self, request, *args, **kwargs):
+        # Fetch the device to delete
+        device = self.get_object(**kwargs)
+        deleted_objects = {
+            "bgp_sessions": [],
+            "device_bgp_sessions": [],
+            "bgp_peer_groups": [],
+            "route_policies": [],
+            "prefix_lists": [],
+            "bgp_community_lists": [],
+            "snmp": [],
+        }
+
+        device_name = device.name
+
+        try:
+            with transaction.atomic():
+                bgp_sessions = BGPSession.objects.filter(
+                    Q(peer_a__device__id=device.id) | Q(peer_b__device__id=device.id)
+                )
+                device_bgp_sessions = DeviceBGPSession.objects.filter(device__id=device.id)
+                bgp_peer_groups = BGPPeerGroup.objects.filter(device__id=device.id)
+                route_policies = RoutePolicy.objects.filter(device__id=device.id)
+                prefix_lists = PrefixList.objects.filter(device__id=device.id)
+                bgp_community_lists = BGPCommunityList.objects.filter(device__id=device.id)
+                snmp = SNMP.objects.filter(device__id=device.id)
+
+                deleted_objects["bgp_sessions"] = [str(val) for val in list(bgp_sessions)]
+                deleted_objects["device_bgp_sessions"] = [
+                    str(val) for val in list(device_bgp_sessions)
+                ]
+                deleted_objects["bgp_peer_groups"] = [str(val) for val in list(bgp_peer_groups)]
+                deleted_objects["route_policies"] = [str(val) for val in list(route_policies)]
+                deleted_objects["prefix_lists"] = [str(val) for val in list(prefix_lists)]
+                deleted_objects["bgp_community_lists"] = [
+                    str(val) for val in list(bgp_community_lists)
+                ]
+                deleted_objects["snmp"] = [str(val) for val in list(snmp)]
+
+                bgp_sessions.delete()
+                device_bgp_sessions.delete()
+                bgp_peer_groups.delete()
+                route_policies.delete()
+                prefix_lists.delete()
+                bgp_community_lists.delete()
+                snmp.delete()
+
+        except Exception as e:
+            # Render the template with an error message
+            return render(request, self.template_name, context={"error": str(e)})
+
+        # Call the parent class's post method to delete the device
+        super().post(request, *args, **kwargs)
+
+        # Return the HTML response with the list of deleted objects
+        return render(
+            request,
+            self.template_name,
+            context={"deleted_device": device_name, "deleted_objects": deleted_objects},
+        )
 
 
 ## ASN views


### PR DESCRIPTION
**Description:**

Add a button to decommission devices from the Device view.
It removes the CMDB objects attached to the device and then remove the device itself from the DCIM.

The list of removed objects are exposed once deleted.