### PR TITLE
fix(api): add ref_name to VRF/VLAN serializers

### DIFF
--- a/netbox_cmdb/netbox_cmdb/api/vlan/serializers.py
+++ b/netbox_cmdb/netbox_cmdb/api/vlan/serializers.py
@@ -12,6 +12,7 @@ class VLANSerializer(ModelSerializer):
     class Meta:
         model = VLAN
         fields = "__all__"
+        ref_name = "NetboxCMDB_VLANSerializer"
 
     def get_display(self, obj):
         return str(obj)
@@ -21,3 +22,4 @@ class NestedVLANSerializer(WritableNestedSerializer):
     class Meta:
         model = VLAN
         fields = ["id", "vid", "name", "description", "tenant"]
+        ref_name = "NetboxCMDB_NestedVLANSerializer"

--- a/netbox_cmdb/netbox_cmdb/api/vrf/serializers.py
+++ b/netbox_cmdb/netbox_cmdb/api/vrf/serializers.py
@@ -12,6 +12,7 @@ class VRFSerializer(ModelSerializer):
     class Meta:
         model = VRF
         fields = "__all__"
+        ref_name = "NetboxCMDB_VRFSerializer"
 
     def get_display(self, obj):
         return str(obj)
@@ -22,3 +23,4 @@ class NestedVRFSerializer(WritableNestedSerializer):
     class Meta:
         model = VRF
         fields = ["id", "name"]
+        ref_name = "NetboxCMDB_NestedVRFSerializer"


### PR DESCRIPTION
Openapi documentation generation is broken because VLAN/VRF serializers are conflicting with the ones existing in netbox core. We must differentiate them with a different ref_name in the class Meta.