### PR TITLE
feat(ui): add Port Layout views

### DIFF
--- a/netbox_cmdb/netbox_cmdb/forms.py
+++ b/netbox_cmdb/netbox_cmdb/forms.py
@@ -1,6 +1,6 @@
 """Forms."""
 
-from dcim.models import Device
+from dcim.models import Device, DeviceRole
 from dcim.models.devices import DeviceType
 from dcim.models.sites import SiteGroup
 from django import forms
@@ -13,6 +13,7 @@ from utilities.forms.fields import DynamicModelChoiceField, MultipleChoiceField
 from netbox_cmdb.choices import AssetMonitoringStateChoices, AssetStateChoices
 from netbox_cmdb.constants import MAX_COMMUNITY_PER_DEVICE
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession
+from netbox_cmdb.models.interface import PortLayout
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
@@ -197,6 +198,30 @@ class SyslogServerForm(NetBoxModelForm):
     class Meta:
         model = SyslogServer
         fields = ["server_address"]
+
+
+class PortLayoutForm(NetBoxModelForm):
+    device_type = DynamicModelChoiceField(
+        queryset=DeviceType.objects.all(),
+        label=_("Device type"),
+    )
+    network_role = DynamicModelChoiceField(
+        queryset=DeviceRole.objects.all(),
+        label=_("Network role"),
+    )
+
+    class Meta:
+        model = PortLayout
+        fields = [
+            "device_type",
+            "network_role",
+            "name",
+            "label_name",
+            "logical_name",
+            "vendor_name",
+            "vendor_short_name",
+            "vendor_long_name",
+        ]
 
 
 class TacacsServerListCleanMixin:

--- a/netbox_cmdb/netbox_cmdb/models/interface.py
+++ b/netbox_cmdb/netbox_cmdb/models/interface.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.urls import reverse
 from netbox.models import ChangeLoggedModel
+from utilities.ordering import naturalize_interface
 
 from netbox_cmdb import protect
 from netbox_cmdb.choices import AssetMonitoringStateChoices, AssetStateChoices
@@ -223,3 +225,18 @@ class PortLayout(ChangeLoggedModel):
     vendor_long_name = models.CharField(
         max_length=64, help_text="The long vendor-specific name of the interface."
     )
+
+    def __str__(self):
+        return f"{self.device_type}--{self.network_role}--{self.name}"
+
+    @property
+    def natural_name(self):
+        """Naturalized version of `name`, suitable as a sort key (etp2 before etp10).
+
+        Lowercased first, since Python string comparison is case-sensitive and would
+        otherwise sort e.g. `etp5B` before `etp5a`.
+        """
+        return naturalize_interface(self.name.lower(), max_length=100)
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_cmdb:portlayout", args=[self.pk])

--- a/netbox_cmdb/netbox_cmdb/navigation.py
+++ b/netbox_cmdb/netbox_cmdb/navigation.py
@@ -53,6 +53,18 @@ menu_items = (
         ),
     ),
     PluginMenuItem(
+        link="plugins:netbox_cmdb:portlayout_list",
+        link_text="Port Layouts",
+        buttons=(
+            PluginMenuButton(
+                link="plugins:netbox_cmdb:portlayout_add",
+                title="Port Layouts",
+                icon_class="mdi mdi-plus-thick",
+                color=ButtonColorChoices.GREEN,
+            ),
+        ),
+    ),
+    PluginMenuItem(
         link="plugins:netbox_cmdb:snmp_list",
         link_text="SNMP",
         buttons=(

--- a/netbox_cmdb/netbox_cmdb/tables.py
+++ b/netbox_cmdb/netbox_cmdb/tables.py
@@ -4,6 +4,7 @@ import django_tables2 as tables
 from netbox.tables import NetBoxTable, columns
 
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession
+from netbox_cmdb.models.interface import PortLayout
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
@@ -133,6 +134,37 @@ class SyslogServerTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = SyslogServer
         fields = ("server_address",)
+
+
+class PortLayoutTable(NetBoxTable):
+    # `natural_name` is a model property; sorting on it requires the table to be fed a list
+    # (in-memory sorting), not a queryset.
+    name = tables.Column(linkify=True, order_by=("natural_name",))
+    device_type = tables.Column(linkify=True)
+    network_role = tables.Column(linkify=True)
+
+    class Meta(NetBoxTable.Meta):
+        model = PortLayout
+        order_by = ("name",)
+        fields = (
+            "pk",
+            "name",
+            "device_type",
+            "network_role",
+            "label_name",
+            "logical_name",
+            "vendor_name",
+            "vendor_short_name",
+            "vendor_long_name",
+        )
+        default_columns = (
+            "name",
+            "label_name",
+            "logical_name",
+            "vendor_name",
+            "vendor_short_name",
+            "vendor_long_name",
+        )
 
 
 class TacacsTable(NetBoxTable):

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/portlayout.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/portlayout.html
@@ -1,0 +1,51 @@
+{% extends 'generic/object.html' %}
+
+{% block content %}
+<div class="row">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">Port Layout</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <td>Device type</td>
+            <td>
+              <a href="{% url 'plugins:netbox_cmdb:portlayout_group' device_type_id=object.device_type.pk network_role_id=object.network_role.pk %}">
+                {{ object.device_type }}
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td>Network role</td>
+            <td>{{ object.network_role }}</td>
+          </tr>
+          <tr>
+            <td>Name</td>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <td>Label name</td>
+            <td>{{ object.label_name }}</td>
+          </tr>
+          <tr>
+            <td>Logical name</td>
+            <td>{{ object.logical_name }}</td>
+          </tr>
+          <tr>
+            <td>Vendor name</td>
+            <td>{{ object.vendor_name }}</td>
+          </tr>
+          <tr>
+            <td>Vendor short name</td>
+            <td>{{ object.vendor_short_name }}</td>
+          </tr>
+          <tr>
+            <td>Vendor long name</td>
+            <td>{{ object.vendor_long_name }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/portlayout_group.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/portlayout_group.html
@@ -1,0 +1,51 @@
+{% extends "base/layout.html" %}
+{% load render_table from django_tables2 %}
+
+{% block title %}Port Layout: {{ device_type }} ({{ network_role }}){% endblock %}
+
+{% block content-wrapper %}
+<div class="content-container">
+  <div class="content px-3">
+    <div class="d-flex justify-content-between align-items-center my-3">
+      {% if perms.netbox_cmdb.add_portlayout %}
+      <a href="{% url 'plugins:netbox_cmdb:portlayout_add' %}?device_type={{ device_type.pk }}&network_role={{ network_role.pk }}&return_url={{ request.path }}"
+         class="btn btn-sm btn-primary">
+        <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add a port
+      </a>
+      {% endif %}
+    </div>
+
+    <div class="row mb-3">
+      <div class="col col-md-6">
+        <div class="card">
+          <h5 class="card-header">Hardware</h5>
+          <div class="card-body">
+            <table class="table table-hover attr-table">
+              <tr>
+                <td>Manufacturer</td>
+                <td>{{ device_type.manufacturer }}</td>
+              </tr>
+              <tr>
+                <td>Device type</td>
+                <td><a href="{{ device_type.get_absolute_url }}">{{ device_type }}</a></td>
+              </tr>
+              <tr>
+                <td>Network role</td>
+                <td><a href="{{ network_role.get_absolute_url }}">{{ network_role }}</a></td>
+              </tr>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">Ports</h5>
+      <div class="card-body table-responsive">
+        {% render_table table 'inc/table.html' %}
+        {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content-wrapper %}

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/portlayout_list.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/portlayout_list.html
@@ -1,0 +1,65 @@
+{% extends "base/layout.html" %}
+
+{% block title %}Port Layouts{% endblock %}
+
+{% block content-wrapper %}
+<div class="content-container">
+  <div class="content px-3">
+    <div class="d-flex justify-content-between align-items-center my-3">
+      <h1 class="page-title my-0">Port Layouts</h1>
+      {% if perms.netbox_cmdb.add_portlayout %}
+      <a href="{% url 'plugins:netbox_cmdb:portlayout_add' %}" class="btn btn-sm btn-primary">
+        <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add
+      </a>
+      {% endif %}
+    </div>
+
+    <div class="row mb-3">
+      <div class="col col-md-4">
+        <form method="get">
+          <div class="input-group">
+            <input type="text" name="q" class="form-control" placeholder="Search hardware or role..." value="{{ search_value }}">
+            <button type="submit" class="btn btn-primary">
+              <i class="mdi mdi-magnify"></i>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">Hardware / Network role combinations</h5>
+      <div class="card-body table-responsive">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th>Manufacturer</th>
+              <th>Hardware (device type)</th>
+              <th>Network role</th>
+              <th>Ports</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for layout in layouts %}
+            <tr>
+              <td>{{ layout.device_type__manufacturer__name }}</td>
+              <td>
+                <a href="{% url 'plugins:netbox_cmdb:portlayout_group' device_type_id=layout.device_type network_role_id=layout.network_role %}">
+                  {{ layout.device_type__model }}
+                </a>
+              </td>
+              <td>{{ layout.network_role__name }}</td>
+              <td>{{ layout.port_count }}</td>
+            </tr>
+            {% empty %}
+            <tr>
+              <td colspan="4" class="text-muted text-center">No port layout found</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content-wrapper %}

--- a/netbox_cmdb/netbox_cmdb/urls.py
+++ b/netbox_cmdb/netbox_cmdb/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
 
 from netbox_cmdb.models.bgp import ASN, BGPSession, DeviceBGPSession, BGPPeerGroup
+from netbox_cmdb.models.interface import PortLayout
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
@@ -27,6 +28,11 @@ from netbox_cmdb.views import (
     DeviceBGPSessionView,
     DeviceDecommissioningView,
     DeviceBGPSessionDeleteView,
+    PortLayoutDeleteView,
+    PortLayoutEditView,
+    PortLayoutGroupListView,
+    PortLayoutGroupView,
+    PortLayoutView,
     RoutePolicyDeleteView,
     RoutePolicyEditView,
     RoutePolicyListView,
@@ -236,6 +242,37 @@ urlpatterns = [
         ObjectChangeLogView.as_view(),
         name="syslog_changelog",
         kwargs={"model": Syslog},
+    ),
+    # PORT LAYOUTS
+    path("port-layout/", PortLayoutGroupListView.as_view(), name="portlayout_list"),
+    path("port-layout/add/", PortLayoutEditView.as_view(), name="portlayout_add"),
+    path(
+        "port-layout/device-type/<int:device_type_id>/role/<int:network_role_id>/",
+        PortLayoutGroupView.as_view(),
+        name="portlayout_group",
+    ),
+    path("port-layout/<int:pk>/", PortLayoutView.as_view(), name="portlayout"),
+    path(
+        "port-layout/<int:pk>/edit/",
+        PortLayoutEditView.as_view(),
+        name="portlayout_edit",
+    ),
+    path(
+        "port-layout/<int:pk>/delete/",
+        PortLayoutDeleteView.as_view(),
+        name="portlayout_delete",
+    ),
+    path(
+        "port-layout/<int:pk>/changelog/",
+        ObjectChangeLogView.as_view(),
+        name="portlayout_changelog",
+        kwargs={"model": PortLayout},
+    ),
+    path(
+        "port-layout/<int:pk>/journal/",
+        ObjectJournalView.as_view(),
+        name="portlayout_journal",
+        kwargs={"model": PortLayout},
     ),
     # SYSLOG SERVERS
     path("syslog-server/", SyslogServerListView.as_view(), name="syslogserver_list"),

--- a/netbox_cmdb/netbox_cmdb/views.py
+++ b/netbox_cmdb/netbox_cmdb/views.py
@@ -3,9 +3,12 @@
 import math
 from datetime import datetime
 
-from dcim.models import Device, Site
+from dcim.models import Device, DeviceRole, DeviceType, Site
 from django.db import transaction
-from django.shortcuts import render
+from django.db.models import Count, Q
+from django.shortcuts import get_object_or_404, render
+from django.views.generic import View
+from django_tables2 import RequestConfig
 from netbox.views.generic import (
     ObjectDeleteView,
     ObjectEditView,
@@ -14,7 +17,9 @@ from netbox.views.generic import (
 )
 from netbox.views.generic.bulk_views import BulkDeleteView
 from utilities.forms import ConfirmationForm
+from utilities.paginator import EnhancedPaginator, get_paginate_count
 from utilities.utils import count_related
+from utilities.views import ObjectPermissionRequiredMixin
 
 from netbox_cmdb.filtersets import (
     ASNFilterSet,
@@ -32,6 +37,7 @@ from netbox_cmdb.forms import (
     BGPSessionFilterSetForm,
     BGPSessionForm,
     DeviceBGPSessionForm,
+    PortLayoutForm,
     RoutePolicyFilterSetForm,
     RoutePolicyForm,
     SNMPCommunityGroupForm,
@@ -49,6 +55,7 @@ from netbox_cmdb.models.bgp import (
     BGPSession,
     DeviceBGPSession,
 )
+from netbox_cmdb.models.interface import PortLayout
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
@@ -58,6 +65,7 @@ from netbox_cmdb.tables import (
     BGPPeerGroupTable,
     BGPSessionTable,
     DeviceBGPSessionTable,
+    PortLayoutTable,
     RoutePolicyTable,
     SNMPCommunityTable,
     SNMPTable,
@@ -442,6 +450,103 @@ class SyslogServerEditView(ObjectEditView):
 
 class SyslogServerDeleteView(ObjectDeleteView):
     queryset = SyslogServer.objects.all()
+
+
+class PortLayoutGroupListView(ObjectPermissionRequiredMixin, View):
+    """Lists every hardware (device type) / network role combination having a port layout."""
+
+    queryset = PortLayout.objects.all()
+
+    def get_required_permission(self):
+        return "netbox_cmdb.view_portlayout"
+
+    def get(self, request):
+        queryset = self.queryset
+        search_value = request.GET.get("q", "").strip()
+        if search_value:
+            queryset = queryset.filter(
+                Q(device_type__model__icontains=search_value)
+                | Q(device_type__manufacturer__name__icontains=search_value)
+                | Q(network_role__name__icontains=search_value)
+            )
+
+        layouts = (
+            queryset.values(
+                "device_type",
+                "device_type__manufacturer__name",
+                "device_type__model",
+                "network_role",
+                "network_role__name",
+            )
+            .annotate(port_count=Count("id"))
+            .order_by(
+                "device_type__manufacturer__name",
+                "device_type__model",
+                "network_role__name",
+            )
+        )
+
+        return render(
+            request,
+            "netbox_cmdb/portlayout_list.html",
+            {
+                "layouts": layouts,
+                "search_value": search_value,
+            },
+        )
+
+
+class PortLayoutGroupView(ObjectPermissionRequiredMixin, View):
+    """Shows all port layout entries of a given hardware (device type) / network role."""
+
+    queryset = PortLayout.objects.all()
+
+    def get_required_permission(self):
+        return "netbox_cmdb.view_portlayout"
+
+    def get(self, request, device_type_id, network_role_id):
+        device_type = get_object_or_404(DeviceType, pk=device_type_id)
+        network_role = get_object_or_404(DeviceRole, pk=network_role_id)
+
+        # Materialize the queryset so the table sorts in Python, allowing natural ordering
+        # of interface names via the `natural_name` model property (etp2 before etp10).
+        # select_related is needed because list data bypasses NetBoxTable's auto-prefetching.
+        table = PortLayoutTable(
+            list(
+                self.queryset.filter(
+                    device_type=device_type, network_role=network_role
+                ).select_related("device_type", "network_role")
+            ),
+            user=request.user,
+        )
+        RequestConfig(
+            request,
+            {"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)},
+        ).configure(table)
+
+        return render(
+            request,
+            "netbox_cmdb/portlayout_group.html",
+            {
+                "device_type": device_type,
+                "network_role": network_role,
+                "table": table,
+            },
+        )
+
+
+class PortLayoutView(ObjectView):
+    queryset = PortLayout.objects.all()
+    template_name = "netbox_cmdb/portlayout.html"
+
+
+class PortLayoutEditView(ObjectEditView):
+    queryset = PortLayout.objects.all()
+    form = PortLayoutForm
+
+
+class PortLayoutDeleteView(ObjectDeleteView):
+    queryset = PortLayout.objects.all()
 
 
 class TacacsListView(ObjectListView):


### PR DESCRIPTION
## Add PortLayout UI

Add a UI for the `PortLayout` model with:

- A grouped list view by device type and network role
- A per-group detail table
- Natural interface-name ordering, so `etp2` appears before `etp10`
- Standard object detail, edit, and delete views
- A navigation-menu entry

<!-- Please respect the guidelines explained in CONTRIBUTING.md -->

## Description

This change adds the user interface for managing `PortLayout` objects. Port layouts are grouped by device type and network role, with a dedicated detail view for each group.

Interface names are sorted naturally to ensure the expected order, for example:

```text
etp1
etp2
etp10