### PR TITLE
Add Link, DeviceInterface and LogicalInterface UI

### DIFF
--- a/netbox_cmdb/netbox_cmdb/filtersets.py
+++ b/netbox_cmdb/netbox_cmdb/filtersets.py
@@ -5,6 +5,7 @@ from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import MultiValueCharFilter
 
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession
+from netbox_cmdb.models.interface import Link
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP
 from netbox_cmdb.models.syslog import Syslog
@@ -220,6 +221,35 @@ class BGPPeerGroupFilterSet(ChangeLoggedModelFilterSet):
             return queryset
         return queryset.filter(
             Q(device__name__icontains=value) | Q(name__icontains=value)
+        ).distinct()
+
+
+class LinkFilterSet(ChangeLoggedModelFilterSet):
+    """Link filterset."""
+
+    q = django_filters.CharFilter(
+        method="search",
+        label="Search",
+    )
+
+    class Meta:
+        model = Link
+        fields = [
+            "id",
+            "interface_a__device__name",
+            "interface_b__device__name",
+            "state",
+            "monitoring_state",
+        ]
+
+    def search(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(interface_a__name__icontains=value)
+            | Q(interface_a__device__name__icontains=value)
+            | Q(interface_b__name__icontains=value)
+            | Q(interface_b__device__name__icontains=value)
         ).distinct()
 
 

--- a/netbox_cmdb/netbox_cmdb/forms.py
+++ b/netbox_cmdb/netbox_cmdb/forms.py
@@ -6,6 +6,7 @@ from dcim.models.sites import SiteGroup
 from django import forms
 from django.utils.translation import gettext as _
 from extras.models import Tag
+from ipam.models import IPAddress
 from netbox.forms import NetBoxModelFilterSetForm, NetBoxModelForm
 from utilities.forms import DynamicModelMultipleChoiceField
 from utilities.forms.fields import DynamicModelChoiceField, MultipleChoiceField
@@ -13,11 +14,18 @@ from utilities.forms.fields import DynamicModelChoiceField, MultipleChoiceField
 from netbox_cmdb.choices import AssetMonitoringStateChoices, AssetStateChoices
 from netbox_cmdb.constants import MAX_COMMUNITY_PER_DEVICE
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession
-from netbox_cmdb.models.interface import PortLayout
+from netbox_cmdb.models.interface import (
+    DeviceInterface,
+    Link,
+    LogicalInterface,
+    PortLayout,
+)
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
 from netbox_cmdb.models.tacacs import Tacacs, TacacsServer, duplicate_priorities
+from netbox_cmdb.models.vlan import VLAN
+from netbox_cmdb.models.vrf import VRF
 
 
 class ASNForm(NetBoxModelForm):
@@ -198,6 +206,104 @@ class SyslogServerForm(NetBoxModelForm):
     class Meta:
         model = SyslogServer
         fields = ["server_address"]
+
+
+class DeviceInterfaceForm(NetBoxModelForm):
+    device = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        label=_("Device"),
+    )
+
+    class Meta:
+        model = DeviceInterface
+        fields = [
+            "device",
+            "name",
+            "enabled",
+            "state",
+            "monitoring_state",
+            "autonegotiation",
+            "speed",
+            "fec",
+            "description",
+        ]
+
+
+class LogicalInterfaceForm(NetBoxModelForm):
+    parent_interface = DynamicModelChoiceField(
+        queryset=DeviceInterface.objects.all(),
+        label=_("Parent interface"),
+    )
+    vrf = DynamicModelChoiceField(
+        queryset=VRF.objects.all(),
+        label=_("VRF"),
+        required=False,
+    )
+    ipv4_address = DynamicModelChoiceField(
+        queryset=IPAddress.objects.all(),
+        label=_("IPv4 address"),
+        required=False,
+    )
+    ipv6_address = DynamicModelChoiceField(
+        queryset=IPAddress.objects.all(),
+        label=_("IPv6 address"),
+        required=False,
+    )
+    untagged_vlan = DynamicModelChoiceField(
+        queryset=VLAN.objects.all(),
+        label=_("Untagged VLAN"),
+        required=False,
+    )
+    tagged_vlans = DynamicModelMultipleChoiceField(
+        queryset=VLAN.objects.all(),
+        label=_("Tagged VLANs"),
+        required=False,
+    )
+    native_vlan = DynamicModelChoiceField(
+        queryset=VLAN.objects.all(),
+        label=_("Native VLAN"),
+        required=False,
+    )
+
+    class Meta:
+        model = LogicalInterface
+        fields = [
+            "parent_interface",
+            "index",
+            "enabled",
+            "state",
+            "monitoring_state",
+            "type",
+            "mode",
+            "mtu",
+            "vrf",
+            "ipv4_address",
+            "ipv6_address",
+            "untagged_vlan",
+            "tagged_vlans",
+            "native_vlan",
+            "description",
+        ]
+
+
+class LinkForm(NetBoxModelForm):
+    interface_a = DynamicModelChoiceField(
+        queryset=DeviceInterface.objects.all(),
+        label=_("Interface A"),
+    )
+    interface_b = DynamicModelChoiceField(
+        queryset=DeviceInterface.objects.all(),
+        label=_("Interface B"),
+    )
+
+    class Meta:
+        model = Link
+        fields = [
+            "interface_a",
+            "interface_b",
+            "state",
+            "monitoring_state",
+        ]
 
 
 class PortLayoutForm(NetBoxModelForm):

--- a/netbox_cmdb/netbox_cmdb/models/interface.py
+++ b/netbox_cmdb/netbox_cmdb/models/interface.py
@@ -193,6 +193,15 @@ class Link(ChangeLoggedModel):
     def __str__(self):
         return f"{self.interface_a} <--> {self.interface_b}"
 
+    def get_state_color(self):
+        return AssetStateChoices.colors.get(self.state)
+
+    def get_monitoring_state_color(self):
+        return AssetMonitoringStateChoices.colors.get(self.monitoring_state)
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_cmdb:link", args=[self.pk])
+
 
 class PortLayout(ChangeLoggedModel):
     """A port layout configuration on a Network device."""

--- a/netbox_cmdb/netbox_cmdb/navigation.py
+++ b/netbox_cmdb/netbox_cmdb/navigation.py
@@ -53,6 +53,18 @@ menu_items = (
         ),
     ),
     PluginMenuItem(
+        link="plugins:netbox_cmdb:link_list",
+        link_text="Links",
+        buttons=(
+            PluginMenuButton(
+                link="plugins:netbox_cmdb:link_add",
+                title="Links",
+                icon_class="mdi mdi-plus-thick",
+                color=ButtonColorChoices.GREEN,
+            ),
+        ),
+    ),
+    PluginMenuItem(
         link="plugins:netbox_cmdb:portlayout_list",
         link_text="Port Layouts",
         buttons=(

--- a/netbox_cmdb/netbox_cmdb/tables.py
+++ b/netbox_cmdb/netbox_cmdb/tables.py
@@ -4,7 +4,7 @@ import django_tables2 as tables
 from netbox.tables import NetBoxTable, columns
 
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession
-from netbox_cmdb.models.interface import PortLayout
+from netbox_cmdb.models.interface import Link, PortLayout
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
@@ -134,6 +134,44 @@ class SyslogServerTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = SyslogServer
         fields = ("server_address",)
+
+
+class LinkTable(NetBoxTable):
+    id = tables.Column(linkify=True)
+    interface_a__device = tables.Column(verbose_name="Device A", linkify=True)
+    # Both sides link to the Link object itself, so clicking either side opens the link.
+    interface_a__name = tables.Column(
+        verbose_name="Interface A",
+        linkify=lambda record: record.get_absolute_url(),
+    )
+    interface_b__device = tables.Column(verbose_name="Device B", linkify=True)
+    interface_b__name = tables.Column(
+        verbose_name="Interface B",
+        linkify=lambda record: record.get_absolute_url(),
+    )
+    state = columns.ChoiceFieldColumn()
+    monitoring_state = columns.ChoiceFieldColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = Link
+        fields = (
+            "pk",
+            "id",
+            "interface_a__device",
+            "interface_a__name",
+            "interface_b__device",
+            "interface_b__name",
+            "state",
+            "monitoring_state",
+        )
+        default_columns = (
+            "interface_a__device",
+            "interface_a__name",
+            "interface_b__device",
+            "interface_b__name",
+            "state",
+            "monitoring_state",
+        )
 
 
 class PortLayoutTable(NetBoxTable):

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/inc/link_side.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/inc/link_side.html
@@ -1,0 +1,131 @@
+{% load helpers %}
+<div class="card">
+  <h5 class="card-header d-flex justify-content-between align-items-center">
+    Interface {{ side }}
+    {% if perms.netbox_cmdb.change_deviceinterface %}
+    <a href="{% url 'plugins:netbox_cmdb:deviceinterface_edit' pk=interface.pk %}?return_url={{ return_url }}"
+       class="btn btn-sm btn-warning">
+      <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit
+    </a>
+    {% endif %}
+  </h5>
+  <div class="card-body">
+    <table class="table table-hover attr-table">
+      <tr>
+        <th>Device</th>
+        <td>{{ interface.device|linkify }}</td>
+      </tr>
+      <tr>
+        <th>Interface</th>
+        <td>{{ interface.name }}</td>
+      </tr>
+      <tr>
+        <th>Enabled</th>
+        <td>{% checkmark interface.enabled %}</td>
+      </tr>
+      <tr>
+        <th>State</th>
+        <td>{% badge interface.get_state_display %}</td>
+      </tr>
+      <tr>
+        <th>Monitoring state</th>
+        <td>{% badge interface.get_monitoring_state_display %}</td>
+      </tr>
+      <tr>
+        <th>Autonegotiation</th>
+        <td>{% checkmark interface.autonegotiation %}</td>
+      </tr>
+      <tr>
+        <th>Speed</th>
+        <td>{{ interface.speed|placeholder }}</td>
+      </tr>
+      <tr>
+        <th>FEC</th>
+        <td>{{ interface.get_fec_display|placeholder }}</td>
+      </tr>
+      <tr>
+        <th>Description</th>
+        <td>{{ interface.description|placeholder }}</td>
+      </tr>
+    </table>
+
+    <h5 class="card-text mt-3">Logical interfaces</h5>
+    {% for logical in interface.logicalinterface.all %}
+    <div class="card mb-2">
+      <h6 class="card-header d-flex justify-content-between align-items-center">
+        {{ interface.name }}.{{ logical.index }}
+        {% if perms.netbox_cmdb.change_logicalinterface %}
+        <a href="{% url 'plugins:netbox_cmdb:logicalinterface_edit' pk=logical.pk %}?return_url={{ return_url }}"
+           class="btn btn-sm btn-warning">
+          <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit
+        </a>
+        {% endif %}
+      </h6>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th>Index</th>
+            <td>{{ logical.index }}</td>
+          </tr>
+          <tr>
+            <th>Type</th>
+            <td>{{ logical.get_type_display|placeholder }}</td>
+          </tr>
+          <tr>
+            <th>Mode</th>
+            <td>{{ logical.get_mode_display|placeholder }}</td>
+          </tr>
+          <tr>
+            <th>Enabled</th>
+            <td>{% checkmark logical.enabled %}</td>
+          </tr>
+          <tr>
+            <th>State</th>
+            <td>{% badge logical.get_state_display %}</td>
+          </tr>
+          <tr>
+            <th>Monitoring state</th>
+            <td>{% badge logical.get_monitoring_state_display %}</td>
+          </tr>
+          <tr>
+            <th>MTU</th>
+            <td>{{ logical.mtu|placeholder }}</td>
+          </tr>
+          <tr>
+            <th>VRF</th>
+            <td>{{ logical.vrf|placeholder }}</td>
+          </tr>
+          <tr>
+            <th>IPv4 address</th>
+            <td>{{ logical.ipv4_address|placeholder|linkify }}</td>
+          </tr>
+          <tr>
+            <th>IPv6 address</th>
+            <td>{{ logical.ipv6_address|placeholder|linkify }}</td>
+          </tr>
+          <tr>
+            <th>Untagged VLAN</th>
+            <td>{{ logical.untagged_vlan|placeholder }}</td>
+          </tr>
+          <tr>
+            <th>Native VLAN</th>
+            <td>{{ logical.native_vlan|placeholder }}</td>
+          </tr>
+          <tr>
+            <th>Tagged VLANs</th>
+            <td>
+              {% for vlan in logical.tagged_vlans.all %}{{ vlan }}{% if not forloop.last %}, {% endif %}{% empty %}{{ ""|placeholder }}{% endfor %}
+            </td>
+          </tr>
+          <tr>
+            <th>Description</th>
+            <td>{{ logical.description|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    {% empty %}
+    <span class="text-muted">None</span>
+    {% endfor %}
+  </div>
+</div>

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/link.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/link.html
@@ -1,0 +1,29 @@
+{% extends 'generic/object.html' %} {% load helpers %}
+{% block title %}{{ object.interface_a.device }} ({{ object.interface_a.name }}) <> {{ object.interface_b.device }} ({{ object.interface_b.name }}){% endblock %}
+{% block content %}
+<div class="row">
+  <div class="col col-12 col-xl-5">
+    {% include 'netbox_cmdb/inc/link_side.html' with interface=object.interface_a side="A" return_url=object.get_absolute_url %}
+  </div>
+  <div class="col col-12 col-xl-2">
+    <div class="card">
+      <h5 class="card-header">Link</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th>State</th>
+            <td>{% badge object.get_state_display bg_color=object.get_state_color %}</td>
+          </tr>
+          <tr>
+            <th>Monitoring State</th>
+            <td>{% badge object.get_monitoring_state_display bg_color=object.get_monitoring_state_color %}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="col col-12 col-xl-5">
+    {% include 'netbox_cmdb/inc/link_side.html' with interface=object.interface_b side="B" return_url=object.get_absolute_url %}
+  </div>
+</div>
+{% endblock %}

--- a/netbox_cmdb/netbox_cmdb/urls.py
+++ b/netbox_cmdb/netbox_cmdb/urls.py
@@ -4,7 +4,7 @@ from django.urls import path
 from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
 
 from netbox_cmdb.models.bgp import ASN, BGPSession, DeviceBGPSession, BGPPeerGroup
-from netbox_cmdb.models.interface import PortLayout
+from netbox_cmdb.models.interface import Link, PortLayout
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
@@ -28,6 +28,13 @@ from netbox_cmdb.views import (
     DeviceBGPSessionView,
     DeviceDecommissioningView,
     DeviceBGPSessionDeleteView,
+    DeviceInterfaceEditView,
+    LinkBulkDeleteView,
+    LinkDeleteView,
+    LinkEditView,
+    LinkListView,
+    LinkView,
+    LogicalInterfaceEditView,
     PortLayoutDeleteView,
     PortLayoutEditView,
     PortLayoutGroupListView,
@@ -242,6 +249,36 @@ urlpatterns = [
         ObjectChangeLogView.as_view(),
         name="syslog_changelog",
         kwargs={"model": Syslog},
+    ),
+    # DEVICE / LOGICAL INTERFACES
+    path(
+        "device-interface/<int:pk>/edit/",
+        DeviceInterfaceEditView.as_view(),
+        name="deviceinterface_edit",
+    ),
+    path(
+        "logical-interface/<int:pk>/edit/",
+        LogicalInterfaceEditView.as_view(),
+        name="logicalinterface_edit",
+    ),
+    # LINKS
+    path("link/", LinkListView.as_view(), name="link_list"),
+    path("link/add/", LinkEditView.as_view(), name="link_add"),
+    path("link/delete/", LinkBulkDeleteView.as_view(), name="link_bulk_delete"),
+    path("link/<int:pk>/", LinkView.as_view(), name="link"),
+    path("link/<int:pk>/edit/", LinkEditView.as_view(), name="link_edit"),
+    path("link/<int:pk>/delete/", LinkDeleteView.as_view(), name="link_delete"),
+    path(
+        "link/<int:pk>/changelog/",
+        ObjectChangeLogView.as_view(),
+        name="link_changelog",
+        kwargs={"model": Link},
+    ),
+    path(
+        "link/<int:pk>/journal/",
+        ObjectJournalView.as_view(),
+        name="link_journal",
+        kwargs={"model": Link},
     ),
     # PORT LAYOUTS
     path("port-layout/", PortLayoutGroupListView.as_view(), name="portlayout_list"),

--- a/netbox_cmdb/netbox_cmdb/views.py
+++ b/netbox_cmdb/netbox_cmdb/views.py
@@ -26,6 +26,7 @@ from netbox_cmdb.filtersets import (
     BGPPeerGroupFilterSet,
     BGPSessionFilterSet,
     DeviceBGPSessionFilterSet,
+    LinkFilterSet,
     RoutePolicyFilterSet,
     SNMPFilterSet,
     SyslogFilterSet,
@@ -37,6 +38,9 @@ from netbox_cmdb.forms import (
     BGPSessionFilterSetForm,
     BGPSessionForm,
     DeviceBGPSessionForm,
+    DeviceInterfaceForm,
+    LinkForm,
+    LogicalInterfaceForm,
     PortLayoutForm,
     RoutePolicyFilterSetForm,
     RoutePolicyForm,
@@ -55,7 +59,12 @@ from netbox_cmdb.models.bgp import (
     BGPSession,
     DeviceBGPSession,
 )
-from netbox_cmdb.models.interface import PortLayout
+from netbox_cmdb.models.interface import (
+    DeviceInterface,
+    Link,
+    LogicalInterface,
+    PortLayout,
+)
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
@@ -65,6 +74,7 @@ from netbox_cmdb.tables import (
     BGPPeerGroupTable,
     BGPSessionTable,
     DeviceBGPSessionTable,
+    LinkTable,
     PortLayoutTable,
     RoutePolicyTable,
     SNMPCommunityTable,
@@ -450,6 +460,50 @@ class SyslogServerEditView(ObjectEditView):
 
 class SyslogServerDeleteView(ObjectDeleteView):
     queryset = SyslogServer.objects.all()
+
+
+## Device interface views
+class DeviceInterfaceEditView(ObjectEditView):
+    queryset = DeviceInterface.objects.all()
+    form = DeviceInterfaceForm
+
+
+## Logical interface views
+class LogicalInterfaceEditView(ObjectEditView):
+    queryset = LogicalInterface.objects.all()
+    form = LogicalInterfaceForm
+
+
+## Link views
+class LinkListView(ObjectListView):
+    queryset = Link.objects.select_related("interface_a__device", "interface_b__device").all()
+    filterset = LinkFilterSet
+    table = LinkTable
+
+
+class LinkView(ObjectView):
+    queryset = Link.objects.select_related(
+        "interface_a__device", "interface_b__device"
+    ).prefetch_related(
+        "interface_a__logicalinterface",
+        "interface_b__logicalinterface",
+    )
+    template_name = "netbox_cmdb/link.html"
+
+
+class LinkEditView(ObjectEditView):
+    queryset = Link.objects.all()
+    form = LinkForm
+
+
+class LinkDeleteView(ObjectDeleteView):
+    queryset = Link.objects.all()
+
+
+class LinkBulkDeleteView(BulkDeleteView):
+    queryset = Link.objects.all()
+    filterset = LinkFilterSet
+    table = LinkTable
 
 
 class PortLayoutGroupListView(ObjectPermissionRequiredMixin, View):


### PR DESCRIPTION
## feat(ui): add Link views

<!-- Please respect the guidelines explained in CONTRIBUTING.md -->

Fixes/Implements: #

## Description

Add a UI for the `Link` model with:

- A list view of links
- Navigation to a link's detail view by clicking either side of the link
- A detail view displaying both device interfaces
- Display of associated logical interfaces, including:
  - VRFs
  - IP addresses
  - VLANs
  - Other related interface data
- Dedicated edit views for every `DeviceInterface` and `LogicalInterface` field
- A navigation-menu entry for accessing the Link views

## Before the commit

The `Link` model did not have a dedicated UI for browsing link relationships or viewing the associated DeviceInterface and Logicalinterfaces.

## After the commit

Users can:

- Access `Link` views from the navigation menu
- Browse the list of links
- Open a link's detail page by selecting either side of the link
- View both device interfaces associated with a link
- Inspect their logical interfaces, including VRFs, IP addresses, and VLANs
- Edit `DeviceInterface` and `LogicalInterface` fields through dedicated edit views