### PR TITLE
feat(ui): additional interface views and CMDB panels on the device page

### DIFF
--- a/netbox_cmdb/netbox_cmdb/filtersets.py
+++ b/netbox_cmdb/netbox_cmdb/filtersets.py
@@ -5,7 +5,7 @@ from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import MultiValueCharFilter
 
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession
-from netbox_cmdb.models.interface import Link
+from netbox_cmdb.models.interface import Link, LogicalInterface
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP
 from netbox_cmdb.models.syslog import Syslog
@@ -250,6 +250,36 @@ class LinkFilterSet(ChangeLoggedModelFilterSet):
             | Q(interface_a__device__name__icontains=value)
             | Q(interface_b__name__icontains=value)
             | Q(interface_b__device__name__icontains=value)
+        ).distinct()
+
+
+class LogicalInterfaceFilterSet(ChangeLoggedModelFilterSet):
+    """Logical interface filterset."""
+
+    q = django_filters.CharFilter(
+        method="search",
+        label="Search",
+    )
+
+    class Meta:
+        model = LogicalInterface
+        fields = [
+            "id",
+            "parent_interface__device__name",
+            "parent_interface__name",
+            "type",
+            "mode",
+            "state",
+            "monitoring_state",
+        ]
+
+    def search(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(parent_interface__name__icontains=value)
+            | Q(parent_interface__device__name__icontains=value)
+            | Q(description__icontains=value)
         ).distinct()
 
 

--- a/netbox_cmdb/netbox_cmdb/models/interface.py
+++ b/netbox_cmdb/netbox_cmdb/models/interface.py
@@ -67,6 +67,15 @@ class DeviceInterface(ChangeLoggedModel):
     def __str__(self):
         return f"{self.device.name}--{self.name}"
 
+    def get_state_color(self):
+        return AssetStateChoices.colors.get(self.state)
+
+    def get_monitoring_state_color(self):
+        return AssetMonitoringStateChoices.colors.get(self.monitoring_state)
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_cmdb:deviceinterface", args=[self.pk])
+
     class Meta:
         unique_together = ("device", "name")
 
@@ -146,6 +155,20 @@ class LogicalInterface(ChangeLoggedModel):
 
     def __str__(self):
         return f"{self.parent_interface.name}--{self.index}"
+
+    @property
+    def name(self):
+        """Conventional display name, e.g. `ge-0/0/32.0`."""
+        return f"{self.parent_interface.name}.{self.index}"
+
+    def get_state_color(self):
+        return AssetStateChoices.colors.get(self.state)
+
+    def get_monitoring_state_color(self):
+        return AssetMonitoringStateChoices.colors.get(self.monitoring_state)
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_cmdb:logicalinterface", args=[self.pk])
 
     def clean(self):
         # List of checks to perform

--- a/netbox_cmdb/netbox_cmdb/navigation.py
+++ b/netbox_cmdb/netbox_cmdb/navigation.py
@@ -65,6 +65,18 @@ menu_items = (
         ),
     ),
     PluginMenuItem(
+        link="plugins:netbox_cmdb:logicalinterface_list",
+        link_text="Logical Interfaces",
+        buttons=(
+            PluginMenuButton(
+                link="plugins:netbox_cmdb:logicalinterface_add",
+                title="Logical Interfaces",
+                icon_class="mdi mdi-plus-thick",
+                color=ButtonColorChoices.GREEN,
+            ),
+        ),
+    ),
+    PluginMenuItem(
         link="plugins:netbox_cmdb:portlayout_list",
         link_text="Port Layouts",
         buttons=(

--- a/netbox_cmdb/netbox_cmdb/tables.py
+++ b/netbox_cmdb/netbox_cmdb/tables.py
@@ -4,7 +4,7 @@ import django_tables2 as tables
 from netbox.tables import NetBoxTable, columns
 
 from netbox_cmdb.models.bgp import ASN, BGPPeerGroup, BGPSession, DeviceBGPSession
-from netbox_cmdb.models.interface import Link, PortLayout
+from netbox_cmdb.models.interface import Link, LogicalInterface, PortLayout
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
@@ -172,6 +172,58 @@ class LinkTable(NetBoxTable):
             "state",
             "monitoring_state",
         )
+
+
+class LogicalInterfaceTable(NetBoxTable):
+    id = tables.Column(linkify=True)
+    # `name` is a model property (parent interface name + index), so it cannot be sorted
+    # directly at the database level; order by the underlying fields instead.
+    name = tables.Column(
+        verbose_name="Name",
+        order_by=("parent_interface__name", "index"),
+        linkify=True,
+    )
+    parent_interface__device = tables.Column(verbose_name="Device", linkify=True)
+    parent_interface = tables.Column(verbose_name="Parent interface", linkify=True)
+    type = tables.Column(verbose_name="Type")
+    mode = tables.Column(verbose_name="Mode")
+    vrf = tables.Column(verbose_name="VRF")
+    ipv4_address = tables.Column(verbose_name="IPv4 address", linkify=True)
+    ipv6_address = tables.Column(verbose_name="IPv6 address", linkify=True)
+    state = columns.ChoiceFieldColumn()
+    monitoring_state = columns.ChoiceFieldColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = LogicalInterface
+        fields = (
+            "pk",
+            "id",
+            "name",
+            "parent_interface__device",
+            "parent_interface",
+            "type",
+            "mode",
+            "vrf",
+            "ipv4_address",
+            "ipv6_address",
+            "state",
+            "monitoring_state",
+            "description",
+        )
+        default_columns = (
+            "name",
+            "parent_interface__device",
+            "parent_interface",
+            "type",
+            "mode",
+            "ipv4_address",
+            "ipv6_address",
+            "state",
+            "monitoring_state",
+        )
+
+    def render_parent_interface(self, value):
+        return value.name
 
 
 class PortLayoutTable(NetBoxTable):

--- a/netbox_cmdb/netbox_cmdb/template_content.py
+++ b/netbox_cmdb/netbox_cmdb/template_content.py
@@ -1,4 +1,8 @@
+from django.db.models import Q
 from extras.plugins import PluginTemplateExtension
+from utilities.ordering import naturalize_interface
+
+from netbox_cmdb.models.interface import DeviceInterface, Link
 
 
 class DecommissioningBase(PluginTemplateExtension):
@@ -19,4 +23,31 @@ class SiteDecommissioning(DecommissioningBase):
     obj = "site"
 
 
-template_extensions = [DeviceDecommissioning, SiteDecommissioning]
+class DeviceCMDBOverview(PluginTemplateExtension):
+    """Shows CMDB interfaces and links related to the device on its detail page."""
+
+    model = "dcim.device"
+
+    def full_width_page(self):
+        device = self.context["object"]
+
+        interfaces = sorted(
+            DeviceInterface.objects.filter(device=device).prefetch_related("logicalinterface"),
+            key=lambda interface: naturalize_interface(interface.name.lower(), max_length=100),
+        )
+        links = (
+            Link.objects.filter(Q(interface_a__device=device) | Q(interface_b__device=device))
+            .select_related("interface_a__device", "interface_b__device")
+            .order_by("interface_a__device__name", "interface_a__name")
+        )
+
+        return self.render(
+            "netbox_cmdb/inc/device_cmdb_overview.html",
+            extra_context={
+                "cmdb_interfaces": interfaces,
+                "cmdb_links": links,
+            },
+        )
+
+
+template_extensions = [DeviceDecommissioning, SiteDecommissioning, DeviceCMDBOverview]

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/deviceinterface.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/deviceinterface.html
@@ -1,0 +1,79 @@
+{% extends 'generic/object.html' %} {% load helpers %}
+{% block title %}{{ object.device }} ({{ object.name }}){% endblock %}
+{% block breadcrumbs %}
+  <li class="breadcrumb-item">{{ object.device|linkify }}</li>
+{% endblock %}
+{% block content %}
+<div class="row">
+  <div class="col col-12 col-xl-6">
+    <div class="card">
+      <h5 class="card-header">Device Interface</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th>Device</th>
+            <td>{{ object.device|linkify }}</td>
+          </tr>
+          <tr>
+            <th>Name</th>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <th>Enabled</th>
+            <td>{% checkmark object.enabled %}</td>
+          </tr>
+          <tr>
+            <th>State</th>
+            <td>{% badge object.get_state_display bg_color=object.get_state_color %}</td>
+          </tr>
+          <tr>
+            <th>Monitoring state</th>
+            <td>{% badge object.get_monitoring_state_display bg_color=object.get_monitoring_state_color %}</td>
+          </tr>
+          <tr>
+            <th>Autonegotiation</th>
+            <td>{% checkmark object.autonegotiation %}</td>
+          </tr>
+          <tr>
+            <th>Speed</th>
+            <td>{{ object.speed|placeholder }}</td>
+          </tr>
+          <tr>
+            <th>FEC</th>
+            <td>{{ object.get_fec_display|placeholder }}</td>
+          </tr>
+          <tr>
+            <th>Description</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="col col-12 col-xl-6">
+    <div class="card">
+      <h5 class="card-header">Logical Interfaces</h5>
+      <div class="card-body">
+        {% for logical in object.logicalinterface.all %}
+        <div class="card mb-2">
+          <h6 class="card-header d-flex justify-content-between align-items-center">
+            <a href="{{ logical.get_absolute_url }}">{{ logical.name }}</a>
+            {% if perms.netbox_cmdb.change_logicalinterface %}
+            <a href="{% url 'plugins:netbox_cmdb:logicalinterface_edit' pk=logical.pk %}?return_url={{ object.get_absolute_url }}"
+               class="btn btn-sm btn-warning">
+              <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit
+            </a>
+            {% endif %}
+          </h6>
+          <div class="card-body">
+            {% include 'netbox_cmdb/inc/logicalinterface_attrs.html' with logical=logical %}
+          </div>
+        </div>
+        {% empty %}
+        <span class="text-muted">None</span>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/inc/device_cmdb_overview.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/inc/device_cmdb_overview.html
@@ -1,0 +1,89 @@
+{% load helpers %}
+<div class="card">
+  <h5 class="card-header d-flex justify-content-between align-items-center">
+    CMDB Interfaces <span class="badge bg-secondary">{{ cmdb_interfaces|length }}</span>
+  </h5>
+  <div class="card-body table-responsive">
+    {% if cmdb_interfaces %}
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Enabled</th>
+          <th>State</th>
+          <th>Monitoring state</th>
+          <th>Autonegotiation</th>
+          <th>Speed</th>
+          <th>FEC</th>
+          <th>Logical interfaces</th>
+          <th>Description</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for interface in cmdb_interfaces %}
+        <tr>
+          <td><a href="{{ interface.get_absolute_url }}">{{ interface.name }}</a></td>
+          <td>{% checkmark interface.enabled %}</td>
+          <td>{% badge interface.get_state_display bg_color=interface.get_state_color %}</td>
+          <td>{% badge interface.get_monitoring_state_display bg_color=interface.get_monitoring_state_color %}</td>
+          <td>{% checkmark interface.autonegotiation %}</td>
+          <td>{{ interface.speed|placeholder }}</td>
+          <td>{{ interface.get_fec_display|placeholder }}</td>
+          <td>
+            {% for logical in interface.logicalinterface.all %}<a href="{{ logical.get_absolute_url }}">{{ logical.name }}</a>{% if not forloop.last %}, {% endif %}{% empty %}{{ ""|placeholder }}{% endfor %}
+          </td>
+          <td>{{ interface.description|placeholder }}</td>
+          <td class="text-end">
+            {% if perms.netbox_cmdb.change_deviceinterface %}
+            <a href="{% url 'plugins:netbox_cmdb:deviceinterface_edit' pk=interface.pk %}?return_url={{ object.get_absolute_url }}"
+               class="btn btn-sm btn-warning">
+              <i class="mdi mdi-pencil" aria-hidden="true"></i>
+            </a>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <span class="text-muted">None</span>
+    {% endif %}
+  </div>
+</div>
+
+<div class="card">
+  <h5 class="card-header d-flex justify-content-between align-items-center">
+    CMDB Links <span class="badge bg-secondary">{{ cmdb_links|length }}</span>
+  </h5>
+  <div class="card-body table-responsive">
+    {% if cmdb_links %}
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th>Device A</th>
+          <th>Interface A</th>
+          <th>Device B</th>
+          <th>Interface B</th>
+          <th>State</th>
+          <th>Monitoring state</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for link in cmdb_links %}
+        <tr>
+          <td>{{ link.interface_a.device|linkify }}</td>
+          <td><a href="{{ link.get_absolute_url }}">{{ link.interface_a.name }}</a></td>
+          <td>{{ link.interface_b.device|linkify }}</td>
+          <td><a href="{{ link.get_absolute_url }}">{{ link.interface_b.name }}</a></td>
+          <td>{% badge link.get_state_display bg_color=link.get_state_color %}</td>
+          <td>{% badge link.get_monitoring_state_display bg_color=link.get_monitoring_state_color %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <span class="text-muted">None</span>
+    {% endif %}
+  </div>
+</div>

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/inc/link_side.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/inc/link_side.html
@@ -17,7 +17,7 @@
       </tr>
       <tr>
         <th>Interface</th>
-        <td>{{ interface.name }}</td>
+        <td><a href="{{ interface.get_absolute_url }}">{{ interface.name }}</a></td>
       </tr>
       <tr>
         <th>Enabled</th>
@@ -53,7 +53,7 @@
     {% for logical in interface.logicalinterface.all %}
     <div class="card mb-2">
       <h6 class="card-header d-flex justify-content-between align-items-center">
-        {{ interface.name }}.{{ logical.index }}
+        <a href="{{ logical.get_absolute_url }}">{{ logical.name }}</a>
         {% if perms.netbox_cmdb.change_logicalinterface %}
         <a href="{% url 'plugins:netbox_cmdb:logicalinterface_edit' pk=logical.pk %}?return_url={{ return_url }}"
            class="btn btn-sm btn-warning">
@@ -62,66 +62,7 @@
         {% endif %}
       </h6>
       <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th>Index</th>
-            <td>{{ logical.index }}</td>
-          </tr>
-          <tr>
-            <th>Type</th>
-            <td>{{ logical.get_type_display|placeholder }}</td>
-          </tr>
-          <tr>
-            <th>Mode</th>
-            <td>{{ logical.get_mode_display|placeholder }}</td>
-          </tr>
-          <tr>
-            <th>Enabled</th>
-            <td>{% checkmark logical.enabled %}</td>
-          </tr>
-          <tr>
-            <th>State</th>
-            <td>{% badge logical.get_state_display %}</td>
-          </tr>
-          <tr>
-            <th>Monitoring state</th>
-            <td>{% badge logical.get_monitoring_state_display %}</td>
-          </tr>
-          <tr>
-            <th>MTU</th>
-            <td>{{ logical.mtu|placeholder }}</td>
-          </tr>
-          <tr>
-            <th>VRF</th>
-            <td>{{ logical.vrf|placeholder }}</td>
-          </tr>
-          <tr>
-            <th>IPv4 address</th>
-            <td>{{ logical.ipv4_address|placeholder|linkify }}</td>
-          </tr>
-          <tr>
-            <th>IPv6 address</th>
-            <td>{{ logical.ipv6_address|placeholder|linkify }}</td>
-          </tr>
-          <tr>
-            <th>Untagged VLAN</th>
-            <td>{{ logical.untagged_vlan|placeholder }}</td>
-          </tr>
-          <tr>
-            <th>Native VLAN</th>
-            <td>{{ logical.native_vlan|placeholder }}</td>
-          </tr>
-          <tr>
-            <th>Tagged VLANs</th>
-            <td>
-              {% for vlan in logical.tagged_vlans.all %}{{ vlan }}{% if not forloop.last %}, {% endif %}{% empty %}{{ ""|placeholder }}{% endfor %}
-            </td>
-          </tr>
-          <tr>
-            <th>Description</th>
-            <td>{{ logical.description|placeholder }}</td>
-          </tr>
-        </table>
+        {% include 'netbox_cmdb/inc/logicalinterface_attrs.html' with logical=logical %}
       </div>
     </div>
     {% empty %}

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/inc/logicalinterface_attrs.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/inc/logicalinterface_attrs.html
@@ -1,0 +1,61 @@
+{% load helpers %}
+<table class="table table-hover attr-table">
+  <tr>
+    <th>Index</th>
+    <td>{{ logical.index }}</td>
+  </tr>
+  <tr>
+    <th>Type</th>
+    <td>{{ logical.get_type_display|placeholder }}</td>
+  </tr>
+  <tr>
+    <th>Mode</th>
+    <td>{{ logical.get_mode_display|placeholder }}</td>
+  </tr>
+  <tr>
+    <th>Enabled</th>
+    <td>{% checkmark logical.enabled %}</td>
+  </tr>
+  <tr>
+    <th>State</th>
+    <td>{% badge logical.get_state_display bg_color=logical.get_state_color %}</td>
+  </tr>
+  <tr>
+    <th>Monitoring state</th>
+    <td>{% badge logical.get_monitoring_state_display bg_color=logical.get_monitoring_state_color %}</td>
+  </tr>
+  <tr>
+    <th>MTU</th>
+    <td>{{ logical.mtu|placeholder }}</td>
+  </tr>
+  <tr>
+    <th>VRF</th>
+    <td>{{ logical.vrf|placeholder }}</td>
+  </tr>
+  <tr>
+    <th>IPv4 address</th>
+    <td>{{ logical.ipv4_address|placeholder|linkify }}</td>
+  </tr>
+  <tr>
+    <th>IPv6 address</th>
+    <td>{{ logical.ipv6_address|placeholder|linkify }}</td>
+  </tr>
+  <tr>
+    <th>Untagged VLAN</th>
+    <td>{{ logical.untagged_vlan|placeholder }}</td>
+  </tr>
+  <tr>
+    <th>Native VLAN</th>
+    <td>{{ logical.native_vlan|placeholder }}</td>
+  </tr>
+  <tr>
+    <th>Tagged VLANs</th>
+    <td>
+      {% for vlan in logical.tagged_vlans.all %}{{ vlan }}{% if not forloop.last %}, {% endif %}{% empty %}{{ ""|placeholder }}{% endfor %}
+    </td>
+  </tr>
+  <tr>
+    <th>Description</th>
+    <td>{{ logical.description|placeholder }}</td>
+  </tr>
+</table>

--- a/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/logicalinterface.html
+++ b/netbox_cmdb/netbox_cmdb/templates/netbox_cmdb/logicalinterface.html
@@ -1,0 +1,35 @@
+{% extends 'generic/object.html' %} {% load helpers %}
+{% block title %}{{ object.parent_interface.device }} ({{ object.name }}){% endblock %}
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item">{{ object.parent_interface.device|linkify }}</li>
+  <li class="breadcrumb-item">
+    <a href="{{ object.parent_interface.get_absolute_url }}">{{ object.parent_interface.name }}</a>
+  </li>
+{% endblock %}
+{% block content %}
+<div class="row">
+  <div class="col col-12 col-xl-6">
+    <div class="card">
+      <h5 class="card-header">Logical Interface</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th>Device</th>
+            <td>{{ object.parent_interface.device|linkify }}</td>
+          </tr>
+          <tr>
+            <th>Parent interface</th>
+            <td><a href="{{ object.parent_interface.get_absolute_url }}">{{ object.parent_interface.name }}</a></td>
+          </tr>
+          <tr>
+            <th>Name</th>
+            <td>{{ object.name }}</td>
+          </tr>
+        </table>
+        {% include 'netbox_cmdb/inc/logicalinterface_attrs.html' with logical=object %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/netbox_cmdb/netbox_cmdb/urls.py
+++ b/netbox_cmdb/netbox_cmdb/urls.py
@@ -4,7 +4,7 @@ from django.urls import path
 from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
 
 from netbox_cmdb.models.bgp import ASN, BGPSession, DeviceBGPSession, BGPPeerGroup
-from netbox_cmdb.models.interface import Link, PortLayout
+from netbox_cmdb.models.interface import DeviceInterface, Link, LogicalInterface, PortLayout
 from netbox_cmdb.models.route_policy import RoutePolicy
 from netbox_cmdb.models.snmp import SNMP, SNMPCommunity
 from netbox_cmdb.models.syslog import Syslog, SyslogServer
@@ -28,13 +28,18 @@ from netbox_cmdb.views import (
     DeviceBGPSessionView,
     DeviceDecommissioningView,
     DeviceBGPSessionDeleteView,
+    DeviceInterfaceDeleteView,
     DeviceInterfaceEditView,
+    DeviceInterfaceView,
     LinkBulkDeleteView,
     LinkDeleteView,
     LinkEditView,
     LinkListView,
     LinkView,
+    LogicalInterfaceDeleteView,
     LogicalInterfaceEditView,
+    LogicalInterfaceListView,
+    LogicalInterfaceView,
     PortLayoutDeleteView,
     PortLayoutEditView,
     PortLayoutGroupListView,
@@ -252,14 +257,73 @@ urlpatterns = [
     ),
     # DEVICE / LOGICAL INTERFACES
     path(
+        "device-interface/add/",
+        DeviceInterfaceEditView.as_view(),
+        name="deviceinterface_add",
+    ),
+    path(
+        "device-interface/<int:pk>/",
+        DeviceInterfaceView.as_view(),
+        name="deviceinterface",
+    ),
+    path(
         "device-interface/<int:pk>/edit/",
         DeviceInterfaceEditView.as_view(),
         name="deviceinterface_edit",
     ),
     path(
+        "device-interface/<int:pk>/delete/",
+        DeviceInterfaceDeleteView.as_view(),
+        name="deviceinterface_delete",
+    ),
+    path(
+        "device-interface/<int:pk>/changelog/",
+        ObjectChangeLogView.as_view(),
+        name="deviceinterface_changelog",
+        kwargs={"model": DeviceInterface},
+    ),
+    path(
+        "device-interface/<int:pk>/journal/",
+        ObjectJournalView.as_view(),
+        name="deviceinterface_journal",
+        kwargs={"model": DeviceInterface},
+    ),
+    path(
+        "logical-interface/",
+        LogicalInterfaceListView.as_view(),
+        name="logicalinterface_list",
+    ),
+    path(
+        "logical-interface/add/",
+        LogicalInterfaceEditView.as_view(),
+        name="logicalinterface_add",
+    ),
+    path(
+        "logical-interface/<int:pk>/",
+        LogicalInterfaceView.as_view(),
+        name="logicalinterface",
+    ),
+    path(
         "logical-interface/<int:pk>/edit/",
         LogicalInterfaceEditView.as_view(),
         name="logicalinterface_edit",
+    ),
+    path(
+        "logical-interface/<int:pk>/delete/",
+        LogicalInterfaceDeleteView.as_view(),
+        name="logicalinterface_delete",
+    ),
+    path(
+        "logical-interface/<int:pk>/changelog/",
+        ObjectChangeLogView.as_view(),
+        name="logicalinterface_changelog",
+        kwargs={"model": LogicalInterface},
+    ),
+    path(
+        "logical-interface/<int:pk>/journal/",
+        ObjectJournalView.as_view(),
+        name="logicalinterface_journal",
+        kwargs={"model": LogicalInterface},
     ),
     # LINKS
     path("link/", LinkListView.as_view(), name="link_list"),

--- a/netbox_cmdb/netbox_cmdb/views.py
+++ b/netbox_cmdb/netbox_cmdb/views.py
@@ -27,6 +27,7 @@ from netbox_cmdb.filtersets import (
     BGPSessionFilterSet,
     DeviceBGPSessionFilterSet,
     LinkFilterSet,
+    LogicalInterfaceFilterSet,
     RoutePolicyFilterSet,
     SNMPFilterSet,
     SyslogFilterSet,
@@ -75,6 +76,7 @@ from netbox_cmdb.tables import (
     BGPSessionTable,
     DeviceBGPSessionTable,
     LinkTable,
+    LogicalInterfaceTable,
     PortLayoutTable,
     RoutePolicyTable,
     SNMPCommunityTable,
@@ -463,15 +465,43 @@ class SyslogServerDeleteView(ObjectDeleteView):
 
 
 ## Device interface views
+class DeviceInterfaceView(ObjectView):
+    queryset = DeviceInterface.objects.select_related("device").prefetch_related("logicalinterface")
+    template_name = "netbox_cmdb/deviceinterface.html"
+
+
 class DeviceInterfaceEditView(ObjectEditView):
     queryset = DeviceInterface.objects.all()
     form = DeviceInterfaceForm
 
 
+class DeviceInterfaceDeleteView(ObjectDeleteView):
+    queryset = DeviceInterface.objects.all()
+
+
 ## Logical interface views
+class LogicalInterfaceListView(ObjectListView):
+    queryset = LogicalInterface.objects.select_related(
+        "parent_interface__device", "vrf", "ipv4_address", "ipv6_address"
+    ).all()
+    filterset = LogicalInterfaceFilterSet
+    table = LogicalInterfaceTable
+
+
+class LogicalInterfaceView(ObjectView):
+    queryset = LogicalInterface.objects.select_related(
+        "parent_interface__device", "vrf", "ipv4_address", "ipv6_address"
+    ).prefetch_related("tagged_vlans")
+    template_name = "netbox_cmdb/logicalinterface.html"
+
+
 class LogicalInterfaceEditView(ObjectEditView):
     queryset = LogicalInterface.objects.all()
     form = LogicalInterfaceForm
+
+
+class LogicalInterfaceDeleteView(ObjectDeleteView):
+    queryset = LogicalInterface.objects.all()
 
 
 ## Link views


### PR DESCRIPTION
  ## Summary
Until now, DeviceInterface and LogicalInterface were only reachable through the Link page. This PR gives them their own list and detail views, and adds CMDB interface/link panels to the device page.

  ### DeviceInterface & LogicalInterface views (0c0e774)
  - New **Logical Interfaces** list view (`/plugins/cmdb/logical-interface/`) with search and filters (device, parent interface, type, mode, state, monitoring state), plus a navigation menu entry with an add button.
  - New **detail views** for both `LogicalInterface` and `DeviceInterface`:
    - The logical interface page shows all attributes (type, mode, MTU, VRF, IP addresses, VLANs, ...) with breadcrumbs to its device and parent interface.
    - The device interface page shows the physical attributes side by side with all of its logical interfaces.
  - The logical interface attribute table is extracted into a shared include (`inc/logicalinterface_attrs.html`), reused by the Link detail page instead of duplicating markup. Interface and logical interface names on the Link page now link to the new views.
  ### CMDB panels on the dcim device page (842e65f)
  - New `PluginTemplateExtension` on `dcim.device` rendering two full-width panels:
    - **CMDB Interfaces**: the device's interfaces, naturally sorted (`etp2` before `etp10`), with state badges, speed/FEC, and their logical interfaces. Every name links to the corresponding detail view.
    - **CMDB Links**: every CMDB link terminating on the device, with both endpoints linkified.
